### PR TITLE
Add python 3.8 support.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,6 +25,8 @@ stages:
           containerImage: python:3.6
         Python37:
           containerImage: python:3.7
+        Python38:
+          containerImage: python:3.8
         PyPy:
           containerImage: pypy:2.7
         PyPy3:
@@ -75,7 +77,7 @@ stages:
   - job: Lint
     pool:
       vmImage: 'Ubuntu-16.04'
-    container: python:3.7
+    container: python:3.8
 
     steps:
     - script: |
@@ -94,7 +96,7 @@ stages:
     - job: pypi
       pool:
         vmImage: 'Ubuntu-16.04'
-      container: python:3.7
+      container: python:3.8
       steps:
       - script: |
           python setup.py sdist bdist_wheel
@@ -109,7 +111,7 @@ stages:
       dependsOn: pypi
       pool:
         vmImage: 'Ubuntu-16.04'
-      container: python:3.7
+      container: python:3.8
 
       steps:
       - task: InstallSSHKey@0

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ classifiers =
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
     Operating System :: OS Independent
     License :: OSI Approved :: Apache Software License
 


### PR DESCRIPTION
Python 3.8 has been [released](https://www.python.org/dev/peps/pep-0569/)! This PR adds classifiers and testing for Python 3.8 where applicable.

Note: windows testing for python 3.8 is [not yet available](https://github.com/microsoft/azure-pipelines-image-generation/blob/1ffbeeee58fc9a1914be9af4091979ca4a06f685/images/win/Vs2019-Server2019-Readme.md).