### PR TITLE
Transition to urllib3.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,8 +16,7 @@ New Relic Telemetry SDK
     :target: https://github.com/psf/black
 
 ``newrelic-telemetry-sdk-python`` provides a Python library for sending Span and Metric data
-into `New Relic <https://newrelic.com>`_ using the Python `requests
-<https://python-requests.org>`_ library.
+into `New Relic <https://newrelic.com>`_ using the Python `urllib3 <https://https://urllib3.readthedocs.io>`_ library.
 
 The current SDK supports sending dimensional metrics to the New Relic Metric API and spans to the New Relic Trace API.
 

--- a/THIRD_PARTY_NOTICES.rst
+++ b/THIRD_PARTY_NOTICES.rst
@@ -8,11 +8,11 @@ These notices are provided below.
 In the event that a required notice is missing or incorrect, please
 notify us by e-mailing open-source@newrelic.com.
 
-`requests <https://pypi.org/project/requests>`__
-------------------------------------------------
+`urllib3 <https://pypi.org/project/urllib3>`__
+----------------------------------------------
 
-Copyright 2018 Kenneth Reitz
+Copyright (c) 2008-2019 Andrey Petrov and contributors (see CONTRIBUTORS.txt)
 
 Distributed under the following license(s):
 
--  `Apache License, Version 2.0 <https://www.apache.org/licenses/LICENSE-2.0>`__
+- `The MIT License <https://opensource.org/licenses/MIT>`_

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -9,7 +9,11 @@ New Relic HTTP Clients
     :members:
     :undoc-members:
     :inherited-members:
-    :exclude-members: URL_TEMPLATE, HOST, PAYLOAD_TYPE, GZIP_HEADER, Client
+    :exclude-members: URL, HOST, PAYLOAD_TYPE, GZIP_HEADER, Client, HTTPResponse
+
+
+.. autoclass:: newrelic_telemetry_sdk.client.HTTPResponse()
+    :members:
 
 Spans
 -----

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -117,6 +117,6 @@ htmlhelp_basename = "newrelic-telemetry-sdkdoc"
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    "python": ("http://docs.python.org/3", None),
-    "requests": ("http://docs.python-requests.org/en/master", None),
+    "https://docs.python.org/3/": None,
+    "https://urllib3.readthedocs.io/en/latest/": None,
 }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,8 +2,7 @@ newrelic-telemetry-sdk: Send data to New Relic!
 ===============================================
 
 ``newrelic-telemetry-sdk`` provides a Python library for sending Span and Metric data
-into `New Relic <https://newrelic.com>`_ using the Python `requests
-<https://python-requests.org>`_ library.
+into `New Relic <https://newrelic.com>`_ using the Python `urllib3 <https://https://urllib3.readthedocs.io>`_ library.
 
 The current SDK supports sending dimensional metrics to the New Relic Metric API and spans to the New Relic Trace API.
 

--- a/setup.py
+++ b/setup.py
@@ -10,5 +10,5 @@ setuptools.setup(
 version = "{version!s}"
 """,
     },
-    install_requires=("requests<3",),
+    install_requires=("urllib3<2",),
 )

--- a/src/newrelic_telemetry_sdk/__init__.py
+++ b/src/newrelic_telemetry_sdk/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from newrelic_telemetry_sdk.client import SpanClient, MetricClient
+from newrelic_telemetry_sdk.client import SpanClient, MetricClient, HTTPError
 from newrelic_telemetry_sdk.span import Span
 from newrelic_telemetry_sdk.metric import GaugeMetric, CountMetric, SummaryMetric
 
@@ -22,6 +22,7 @@ except ImportError:  # pragma: no cover
     __version__ = "unknown"  # pragma: no cover
 
 __all__ = (
+    "HTTPError",
     "SpanClient",
     "MetricClient",
     "Span",

--- a/src/newrelic_telemetry_sdk/client.py
+++ b/src/newrelic_telemetry_sdk/client.py
@@ -23,7 +23,7 @@ except ImportError:  # pragma: no cover
 
 USER_AGENT = "NewRelic-Python-TelemetrySDK/{}".format(__version__)
 
-__all__ = ("SpanClient", "MetricClient")
+__all__ = ("SpanClient", "MetricClient", "HTTPError", "HTTPResponse")
 
 
 class HTTPError(ValueError):

--- a/src/newrelic_telemetry_sdk/client.py
+++ b/src/newrelic_telemetry_sdk/client.py
@@ -79,7 +79,7 @@ class Client(object):
     Usage::
 
         >>> import os
-        >>> insert_key = os.environ.get("NEW_RELIC_INSERT_KEY")
+        >>> insert_key = os.environ.get("NEW_RELIC_INSERT_KEY", "")
         >>> client = Client(insert_key, host="metric-api.newrelic.com")
         >>> response = client.send({})
     """
@@ -167,7 +167,7 @@ class SpanClient(Client):
     Usage::
 
         >>> import os
-        >>> insert_key = os.environ.get("NEW_RELIC_INSERT_KEY")
+        >>> insert_key = os.environ.get("NEW_RELIC_INSERT_KEY", "")
         >>> span_client = SpanClient(insert_key)
         >>> response = span_client.send({})
     """
@@ -194,7 +194,7 @@ class MetricClient(Client):
     Usage::
 
         >>> import os
-        >>> insert_key = os.environ.get("NEW_RELIC_INSERT_KEY")
+        >>> insert_key = os.environ.get("NEW_RELIC_INSERT_KEY", "")
         >>> metric_client = MetricClient(insert_key)
         >>> response = metric_client.send({})
     """

--- a/src/newrelic_telemetry_sdk/client.py
+++ b/src/newrelic_telemetry_sdk/client.py
@@ -70,10 +70,10 @@ class Client(object):
 
     :param insert_key: Insights insert key
     :type insert_key: str
-    :param url: The API endpoint.
-    :type url: str
-    :param compression_threshold: Compress if number of bytes in payload is
-        above this threshold.
+    :param host: (optional) Override the host for the client.
+    :type host: str
+    :param compression_threshold: (optional) Compress if number of bytes in
+        payload is above this threshold. (Default: 64K)
     :type compression_threshold: int
 
     Usage::
@@ -160,8 +160,8 @@ class SpanClient(Client):
     :type insert_key: str
     :param host: (optional) Override the host for the span API endpoint.
     :type host: str
-    :param compression_threshold: Compress if number of bytes in payload is
-        above this threshold. (Default: 64K)
+    :param compression_threshold: (optional) Compress if number of bytes in
+        payload is above this threshold. (Default: 64K)
     :type compression_threshold: int
 
     Usage::
@@ -187,8 +187,8 @@ class MetricClient(Client):
     :param metric_host: (optional) Override the host for the metric API
         endpoint.
     :type metric_host: str
-    :param compression_threshold: Compress if number of bytes in payload is
-        above this threshold. (Default: 64K)
+    :param compression_threshold: (optional) Compress if number of bytes in
+        payload is above this threshold. (Default: 64K)
     :type compression_threshold: int
 
     Usage::


### PR DESCRIPTION
# Breaking API Change
Note, this will force a bump to version 0.2

Python's [requests](https://github.com/psf/requests) library introduces a lot of dependencies that aren't necessarily used ([chardet](https://github.com/chardet/chardet) for example).

In order to reduce our dependency list (as well as the LGPL chardet dependency), this PR switches over to using pure `urllib3` calls.

# Response object compatibility
This PR introduces a new `HTTPResponse` object that maintains _some_ compatibility with [requests](https://github.com/psf/requests).

## Methods
* `json()`: returns a dictionary containing the json loaded response payload
* `raise_for_status()`: raises an `HTTPError` when the response is unsuccessful

## Properties / attributes
* `status_code` has moved to `status`
* `ok`: returns True if the response status is in the range [200, 300)

## Broken compatibility
* The `text` property is not maintained. It is expected that the `json()` method be used if response parsing is necessary. This may be added in the future if requested.
