### PR TITLE
Remove metric defaults.

### DIFF
--- a/src/newrelic_telemetry_sdk/metric.py
+++ b/src/newrelic_telemetry_sdk/metric.py
@@ -168,17 +168,13 @@ class SummaryMetric(Metric):
 
     :param name: The name of the metric.
     :type name: str
-    :param count: (optional) The initial count in the summary metric.
-        Defaults to 0.
+    :param count: The count in the summary metric.
     :type count: int
-    :param sum: (optional) The initial sum in the summary metric.
-        Defaults to 0.
+    :param sum: The sum in the summary metric.
     :type sum: int or float
-    :param min: (optional) The initial min in the minmary metric. Defaults to
-        float('inf').
+    :param min: The minimum value in the summary metric.
     :type min: int or float
-    :param max: (optional) The initial max in the maxmary metric. Defaults to
-        float('-inf').
+    :param max: The maximum value in the summary metric.
     :type max: int or float
     :param tags: (optional) A set of tags that can be used to filter this
         metric in the New Relic UI.
@@ -199,15 +195,7 @@ class SummaryMetric(Metric):
     """
 
     def __init__(
-        self,
-        name,
-        count=0,
-        sum=0,
-        min=float("inf"),
-        max=float("-inf"),
-        tags=None,
-        interval_ms=None,
-        end_time_ms=None,
+        self, name, count, sum, min, max, tags=None, interval_ms=None, end_time_ms=None
     ):
         value = {"count": count, "sum": sum, "min": min, "max": max}
         super(SummaryMetric, self).__init__(name, value, tags, interval_ms, end_time_ms)

--- a/src/newrelic_telemetry_sdk/metric.py
+++ b/src/newrelic_telemetry_sdk/metric.py
@@ -133,7 +133,7 @@ class CountMetric(Metric):
 
     :param name: The name of the metric.
     :type name: str
-    :param value: (optional) The initial metric value. Defaults to 0.
+    :param value: The metric count value.
     :type value: int or float
     :param tags: (optional) A set of tags that can be used to filter this
         metric in the New Relic UI.
@@ -148,12 +148,12 @@ class CountMetric(Metric):
     Usage::
 
         >>> from newrelic_telemetry_sdk import CountMetric
-        >>> metric = CountMetric('response_status', tags={'code': 200})
+        >>> metric = CountMetric('response_status', 0, tags={'code': 200})
         >>> metric.value
         0
     """
 
-    def __init__(self, name, value=0, tags=None, interval_ms=None, end_time_ms=None):
+    def __init__(self, name, value, tags=None, interval_ms=None, end_time_ms=None):
         super(CountMetric, self).__init__(name, value, tags, interval_ms, end_time_ms)
 
         self["type"] = "count"

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -32,7 +32,7 @@ def test_metric_defaults(method, freeze_time):
 
 
 def test_count_metric_defaults(freeze_time):
-    metric = CountMetric("name")
+    metric = CountMetric("name", 0)
     assert metric["type"] == "count"
     assert metric["name"] == "name"
     assert metric["value"] == 0
@@ -44,15 +44,10 @@ def test_count_metric_defaults(freeze_time):
 
 
 def test_summary_metric_defaults(freeze_time):
-    metric = SummaryMetric("name")
+    metric = SummaryMetric("name", 0, 0, 0, 0)
     assert metric["type"] == "summary"
     assert metric["name"] == "name"
-    assert metric["value"] == {
-        "count": 0,
-        "sum": 0,
-        "min": float("inf"),
-        "max": float("-inf"),
-    }
+    assert metric["value"] == {"count": 0, "sum": 0, "min": 0, "max": 0}
     assert metric["timestamp"] == 2000
     assert type(metric["timestamp"]) is int
 


### PR DESCRIPTION
# Breaking API change

The default values provided in the metric class init aren't particularly helpful, especially considering that `SummaryMetric` has invalid infinity / -infinity default values for min and max respectively.

This PR makes the values for `CountMetric` and `SummaryMetric` required inputs.