### PR TITLE
Ensure tags are of type dict on spans / metrics.

### DIFF
--- a/src/newrelic_telemetry_sdk/metric.py
+++ b/src/newrelic_telemetry_sdk/metric.py
@@ -47,7 +47,7 @@ class Metric(dict):
         self["timestamp"] = int(end_time_ms or (time.time() * 1000)) - interval
 
         if tags:
-            self["attributes"] = tags
+            self["attributes"] = dict(tags)
 
     def copy(self):
         cls = type(self)

--- a/src/newrelic_telemetry_sdk/span.py
+++ b/src/newrelic_telemetry_sdk/span.py
@@ -65,7 +65,7 @@ class Span(dict):
         self["trace.id"] = trace_id or ("%016x" % random.getrandbits(64))
         self["timestamp"] = int(start_time_ms or (time.time() * 1000))
 
-        attributes = tags and tags.copy() or {}
+        attributes = tags and dict(tags) or {}
         self["attributes"] = attributes
 
         attributes["name"] = name

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -16,6 +16,22 @@ import pytest
 from newrelic_telemetry_sdk.metric import Metric, CountMetric, SummaryMetric
 
 
+class CustomMapping(object):
+    def __getitem__(self, key):
+        if key == "foo":
+            return "bar"
+        raise KeyError(key)
+
+    def __iter__(self):
+        return iter(("foo",))
+
+    def __len__(self):
+        return 1
+
+    def keys(self):
+        return ("foo",)
+
+
 @pytest.mark.parametrize("method", (None, "from_value"))
 def test_metric_defaults(method, freeze_time):
     new = Metric
@@ -59,6 +75,7 @@ def test_summary_metric_defaults(freeze_time):
     "arg_name,arg_value,metric_key,metric_value",
     (
         ("tags", {"foo": "bar"}, "attributes", {"foo": "bar"}),
+        ("tags", CustomMapping(), "attributes", {"foo": "bar"}),
         ("interval_ms", 2000, "interval.ms", 2000),
         ("end_time_ms", 1000, "timestamp", 1000),
     ),

--- a/tests/test_span.py
+++ b/tests/test_span.py
@@ -16,6 +16,22 @@ import pytest
 from newrelic_telemetry_sdk.span import Span
 
 
+class CustomMapping(object):
+    def __getitem__(self, key):
+        if key == "foo":
+            return "bar"
+        raise KeyError(key)
+
+    def __iter__(self):
+        return iter(("foo",))
+
+    def __len__(self):
+        return 1
+
+    def keys(self):
+        return ("foo",)
+
+
 def test_span_defaults(freeze_time):
     span = Span("name")
     attributes = span["attributes"]
@@ -91,3 +107,10 @@ def test_span_duration_zero():
     value = span["attributes"]["duration.ms"]
     assert value == 0
     assert isinstance(value, int)
+
+
+def test_span_custom_mapping_for_tags():
+    span = Span("name", tags=CustomMapping())
+
+    assert type(span["attributes"]) is dict
+    assert span["attributes"]["foo"] == "bar"


### PR DESCRIPTION
Tags can be provided as a custom mapping class. These custom mapping classes may not be mutable and they may not support all keys.

Any mapping provided should be converted into dict types for internal representation on a span or metric.