### PR TITLE
Add batch and harvester components.

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -1,0 +1,83 @@
+Advanced Usage
+==============
+
+The telemetry SDK includes components to simplify data aggregation for long running applications.
+
+Batches
+-------
+
+Batches provide a standard interface for aggregating and flushing data across different data types. This interface is used by the harvester to forward data from batches to a client.
+
+Batches will automatically track the interval over which data is aggregated so you don't have to manually set ``interval_ms`` on metrics!
+
+All public batch methods are thread safe.
+
+Batches are broken out by data type that they contain:
+
++----------------------------------------------------------+---------------------------------------------------------------------------+
+| Data Type                                                | Batch Type                                                                |
++==========================================================+===========================================================================+
+| :class:`Metric <newrelic_telemetry_sdk.metric.Metric>`   | :class:`MetricBatch <newrelic_telemetry_sdk.metric_batch.MetricBatch>`    |
++----------------------------------------------------------+---------------------------------------------------------------------------+
+| :class:`Span <newrelic_telemetry_sdk.span.Span>`         | :class:`SpanBatch <newrelic_telemetry_sdk.span_batch.SpanBatch>`          |
++----------------------------------------------------------+---------------------------------------------------------------------------+
+
+Example
+^^^^^^^
+
+.. code-block:: python
+
+    from newrelic_telemetry_sdk import CountMetric, MetricBatch
+
+    metric_batch = MetricBatch()
+
+    # Record that there have been 5 errors
+    # Interval is not required since the metric will be placed in a batch!
+    errors = CountMetric(name="errors", value=5)
+    metric_batch.record(errors)
+
+    # Calling flush will clear the batch and reset the interval start time
+    items, common = metric_batch.flush()
+
+    # The interval is automatically set by the batch!
+    print(common["interval.ms"])
+
+Harvester
+---------
+
+A :class:`Harvester <newrelic_telemetry_sdk.harvester.Harvester>` flushes a batch and sends data through a client at a fixed harvest interval.
+
+The :class:`Harvester <newrelic_telemetry_sdk.harvester.Harvester>` class is a :class:`threading.Thread` and has :meth:`start <newrelic_telemetry_sdk.harvester.Harvester.start>` and :meth:`stop <newrelic_telemetry_sdk.harvester.Harvester.stop>` methods.
+
+The :meth:`record <newrelic_telemetry_sdk.harvester.Harvester.record>` method intentionally has the same signature as a batch's record method. For all intents and purposes, the harvester can be treated as a batch that will be periodically flushed and sent to New Relic.
+
+Example
+^^^^^^^
+The example code assumes you've set the following environment variables:
+
+* ``NEW_RELIC_INSERT_KEY``
+
+.. code-block:: python
+
+    import atexit
+    import os
+    from newrelic_telemetry_sdk import GaugeMetric, MetricBatch, MetricClient, Harvester
+
+    metric_client = MetricClient(os.environ['NEW_RELIC_INSERT_KEY'])
+    metric_batch = MetricBatch()
+    metric_harvester = Harvester(metric_client, metric_batch)
+
+    # Send any buffered data when the process exits
+    def wait_to_send_metric_data(timeout=5.0):
+        metric_harvester.stop()
+        metric_harvester.join(timeout=timeout)
+
+    atexit.register(wait_to_send_metric_data)
+
+    # Start the harvester background thread
+    metric_harvester.start()
+
+    # Data is now recorded through the harvester
+    # The data will buffer and send every 5 seconds or at process exit
+    temperature = GaugeMetric("temperature", 78.6, {"units": "Farenheit"})
+    metric_harvester.record(temperature)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -26,3 +26,20 @@ Metrics
     :members:
     :undoc-members:
     :show-inheritance:
+
+
+Batches
+-------
+.. automodule:: newrelic_telemetry_sdk.metric_batch
+    :members:
+
+.. automodule:: newrelic_telemetry_sdk.span_batch
+    :members:
+
+Harvester
+---------
+.. automodule:: newrelic_telemetry_sdk.harvester
+    :members:
+    :exclude-members: LOCK_CLS, EVENT_CLS, run, daemon
+    :show-inheritance:
+    :inherited-members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,6 +26,14 @@ Get Started!
 
    quickstart
 
+Advanced Usage
+--------------
+
+.. toctree::
+   :maxdepth: 2
+
+   advanced
+
 API Reference
 -------------
 

--- a/src/newrelic_telemetry_sdk/__init__.py
+++ b/src/newrelic_telemetry_sdk/__init__.py
@@ -16,6 +16,7 @@ from newrelic_telemetry_sdk.client import SpanClient, MetricClient, HTTPError
 from newrelic_telemetry_sdk.span import Span
 from newrelic_telemetry_sdk.metric import GaugeMetric, CountMetric, SummaryMetric
 from newrelic_telemetry_sdk.metric_batch import MetricBatch
+from newrelic_telemetry_sdk.span_batch import SpanBatch
 from newrelic_telemetry_sdk.harvester import Harvester
 
 try:
@@ -32,5 +33,6 @@ __all__ = (
     "CountMetric",
     "SummaryMetric",
     "MetricBatch",
+    "SpanBatch",
     "Harvester",
 )

--- a/src/newrelic_telemetry_sdk/__init__.py
+++ b/src/newrelic_telemetry_sdk/__init__.py
@@ -15,6 +15,7 @@
 from newrelic_telemetry_sdk.client import SpanClient, MetricClient, HTTPError
 from newrelic_telemetry_sdk.span import Span
 from newrelic_telemetry_sdk.metric import GaugeMetric, CountMetric, SummaryMetric
+from newrelic_telemetry_sdk.metric_batch import MetricBatch
 
 try:
     from newrelic_telemetry_sdk.version import version as __version__
@@ -29,4 +30,5 @@ __all__ = (
     "GaugeMetric",
     "CountMetric",
     "SummaryMetric",
+    "MetricBatch",
 )

--- a/src/newrelic_telemetry_sdk/__init__.py
+++ b/src/newrelic_telemetry_sdk/__init__.py
@@ -16,6 +16,7 @@ from newrelic_telemetry_sdk.client import SpanClient, MetricClient, HTTPError
 from newrelic_telemetry_sdk.span import Span
 from newrelic_telemetry_sdk.metric import GaugeMetric, CountMetric, SummaryMetric
 from newrelic_telemetry_sdk.metric_batch import MetricBatch
+from newrelic_telemetry_sdk.harvester import Harvester
 
 try:
     from newrelic_telemetry_sdk.version import version as __version__
@@ -31,4 +32,5 @@ __all__ = (
     "CountMetric",
     "SummaryMetric",
     "MetricBatch",
+    "Harvester",
 )

--- a/src/newrelic_telemetry_sdk/harvester.py
+++ b/src/newrelic_telemetry_sdk/harvester.py
@@ -1,0 +1,123 @@
+# Copyright 2020 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import time
+import threading
+
+_logger = logging.getLogger(__name__)
+
+
+class Harvester(threading.Thread):
+    """Report data to New Relic at a fixed interval
+
+    The Harvester is a thread implementation which sends data to New Relic every
+    ``harvest_interval`` seconds or until the data buffers are full.
+
+    The reporter will automatically handle error conditions which may occur
+    such as:
+
+    * Network timeouts
+    * New Relic errors
+
+    :param client: The client instance to call in order to send data.
+    :type client: newrelic_sdk.client.Client
+    :param batch: A batch with record and flush interfaces.
+    :param harvest_interval: (optional) The interval in seconds at which data
+        will be reported. (default 5)
+    :type harvest_interval: int or float
+
+    Example::
+
+        >>> import os
+        >>> insert_key = os.environ.get("NEW_RELIC_INSERT_KEY", "")
+        >>> from newrelic_telemetry_sdk import MetricBatch, MetricClient
+        >>> metric_client = MetricClient(insert_key)
+        >>> metric_batch = MetricBatch()
+        >>> harvester = Harvester(metric_client, metric_batch)
+        >>> harvester.start()
+        >>> harvester.stop()
+    """
+
+    EVENT_CLS = threading.Event
+
+    def __init__(self, client, batch, harvest_interval=5):
+        super(Harvester, self).__init__()
+        self.daemon = True
+        self.harvest_interval = harvest_interval
+        self._client = client
+        self._batch = batch
+        self._harvest_interval_start = 0
+        self._shutdown = self.EVENT_CLS()
+
+    def _send(self, items, common=None):
+        """Send items through the harvester client, handling any exceptions"""
+        if items:
+            try:
+                response = self._client.send_batch(items, common=common)
+                if not response.ok:
+                    _logger.error(
+                        "New Relic send_batch failed with status code: %r",
+                        response.status,
+                    )
+            except Exception:
+                _logger.exception("New Relic send_batch failed with an exception.")
+
+    def _wait_for_harvest(self):
+        """Tracks and adjusts time required to maintain the harvest interval"""
+        current_time = time.time()
+        interval_start = self._harvest_interval_start or current_time
+        timeout = max(self.harvest_interval - (current_time - interval_start), 0)
+        shutdown = self._shutdown.wait(timeout)
+        self._harvest_interval_start = time.time()
+        return shutdown
+
+    def run(self):
+        """Main loop of the harvester thread"""
+        while not self._wait_for_harvest():
+            self._send(*self._batch.flush())
+
+        # Flush any remaining data and send it prior to shutting down
+        self._send(*self._batch.flush())
+
+        # Clear all references to client and batch to close connections and
+        # deallocate batch
+        self._batch = self._client = None
+
+    def record(self, item):
+        """Add an item to the batch to be harvested
+
+        Calling record with an item will merge it into the batch maintained by
+        this harvester.
+
+        :param item: A metric or span to be merged into a batch.
+        """
+        self._batch.record(item)
+
+    def stop(self, timeout=None):
+        """Terminate the harvester.
+
+        This will request and wait for the thread to terminate. The thread will
+        not terminate immediately since any pending data will be sent.
+
+        When the timeout argument is present, this function will exit after at
+        most timeout seconds. The thread may still be alive after this function
+        exits if the timeout is reached but the thread hasn't yet terminated.
+
+        :param timeout: (optional) A timeout in seconds to wait for the thread
+            to shut down or None to block until the thread exits (default: None)
+        :type timeout: int or float
+        """
+        self._shutdown.set()
+        self.join(timeout=timeout)

--- a/src/newrelic_telemetry_sdk/metric_batch.py
+++ b/src/newrelic_telemetry_sdk/metric_batch.py
@@ -1,0 +1,118 @@
+# Copyright 2020 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import threading
+import time
+
+from newrelic_telemetry_sdk.metric import CountMetric, SummaryMetric
+
+
+class MetricBatch(object):
+    """Maps a metric identity to its aggregated value
+
+    This is used to hold unfinalized metrics for further aggregation until they
+    are flushed to a backend.
+
+    :param tags: (optional) A dictionary of tags to attach to all flushes.
+    :type tags: dict
+    """
+
+    LOCK_CLS = threading.Lock
+
+    def __init__(self, tags=None):
+        self._interval_start = int(time.time() * 1000.0)
+        self._lock = self.LOCK_CLS()
+        self._batch = {}
+        tags = tags and tags.copy() or {}
+        self._common = {"attributes": tags}
+
+    @staticmethod
+    def create_identity(metric):
+        """Creates a deterministic hashable identity for a metric
+
+        :param metric: A New Relic metric object
+        :type metric: newrelic_telemetry_sdk.metric.Metric
+
+        Usage::
+
+            >>> from newrelic_telemetry_sdk import GaugeMetric
+            >>> metric_a = GaugeMetric('foo', 0, tags={'units': 'C'})
+            >>> metric_b = GaugeMetric('foo', 1, tags={'units': 'C'})
+            >>> MetricBatch.create_identity(metric_a) == \
+                MetricBatch.create_identity(metric_b)
+            True
+        """
+        tags = metric.tags
+        if tags:
+            tags = frozenset(tags.items())
+        identity = (type(metric), metric.name, tags)
+        return identity
+
+    def record(self, item):
+        """Merge a metric into the batch
+
+        :param item: The metric to merge into the batch.
+        :type item: newrelic_telemetry_sdk.metric.Metric
+        """
+        identity = self.create_identity(item)
+
+        with self._lock:
+            if identity in self._batch:
+                merged = self._batch[identity]
+                value = item["value"]
+
+                if isinstance(item, SummaryMetric):
+                    merged_value = merged["value"]
+                    merged_value["count"] += value["count"]
+                    merged_value["sum"] += value["sum"]
+                    merged_value["min"] = min(value["min"], merged_value["min"])
+                    merged_value["max"] = max(value["max"], merged_value["max"])
+                elif isinstance(item, CountMetric):
+                    merged["value"] += value
+                else:
+                    merged["value"] = value
+
+            else:
+                item = self._batch[identity] = item.copy()
+                # Timestamp will now be tracked as part of the batch
+                item.pop("timestamp")
+
+    def flush(self):
+        """Flush all metrics from the batch
+
+        This method returns all metrics in the batch and a common block
+        representing timestamp as the start time for the period since creation
+        or last flush, and interval representing the total amount of time in
+        milliseconds between flushes.
+
+        As a side effect, the batch's interval is reset in anticipation of
+        subsequent calls to flush.
+
+        :returns: A tuple of (metrics, common)
+        :rtype: tuple
+        """
+        with self._lock:
+            batch = self._batch
+            items = tuple(batch.values())
+            batch.clear()
+
+            common = self._common.copy()
+            common["timestamp"] = self._interval_start
+            now = int(time.time() * 1000.0)
+            interval = now - self._interval_start
+            common["interval.ms"] = interval
+
+            self._interval_start = now
+
+        return items, common

--- a/src/newrelic_telemetry_sdk/span_batch.py
+++ b/src/newrelic_telemetry_sdk/span_batch.py
@@ -1,0 +1,58 @@
+# Copyright 2020 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import threading
+
+
+class SpanBatch(object):
+    """Aggregates spans, providing a record / flush interface.
+
+    :param tags: (optional) A dictionary of tags to attach to all flushes.
+    :type tags: dict
+    """
+
+    LOCK_CLS = threading.Lock
+
+    def __init__(self, tags=None):
+        self._lock = self.LOCK_CLS()
+        self._batch = []
+        tags = tags and tags.copy()
+        if tags:
+            self._common = {"attributes": tags}
+        else:
+            self._common = None
+
+    def record(self, item):
+        """Merge a span into the batch
+
+        :param item: The span to merge into the batch.
+        :type item: newrelic_telemetry_sdk.metric.Span
+        """
+        with self._lock:
+            self._batch.append(item)
+
+    def flush(self):
+        """Flush all spans from the batch
+
+        This method returns all metrics in the batch and a common block
+        representing any tags if applicable.
+
+        :returns: A tuple of (spans, common)
+        :rtype: tuple
+        """
+        with self._lock:
+            batch = tuple(self._batch)
+            self._batch[:] = []
+
+        common = self._common and self._common.copy()
+        return batch, common

--- a/tests/test_harvester.py
+++ b/tests/test_harvester.py
@@ -1,0 +1,183 @@
+# Copyright 2020 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import time
+
+import pytest
+from newrelic_telemetry_sdk.harvester import Harvester
+
+
+class Response(object):
+    status = 202
+    ok = True
+
+
+class FakeBatch(object):
+    def __init__(self):
+        self.contents = []
+
+    def record(self, item):
+        self.contents.append(item)
+
+    def flush(self):
+        contents = tuple(self.contents)
+        self.contents = []
+        return contents, None
+
+
+class FakeClient(object):
+    def __init__(self):
+        self.sent = []
+        self.response = Response()
+
+    def send_batch(self, items, common=None):
+        self.sent.append((items, common))
+        return self.response
+
+
+@pytest.fixture
+def batch():
+    return FakeBatch()
+
+
+@pytest.fixture
+def client():
+    return FakeClient()
+
+
+@pytest.fixture
+def harvester(client, batch):
+    harvester = Harvester(client, batch)
+    return harvester
+
+
+def test_record(harvester, batch):
+    item = object()
+    harvester.record(item)
+    assert batch.contents == [item]
+
+
+def test_run_once(harvester, client):
+    harvester.harvest_interval = 0.01
+    send_batch = client.send_batch
+
+    def shutdown_after_send(*args, **kwargs):
+        result = send_batch(*args, **kwargs)
+        harvester._shutdown.set()
+        return result
+
+    client.send_batch = shutdown_after_send
+    item = object()
+    harvester.record(item)
+
+    harvester.run()
+
+    assert client.sent == [((item,), None)]
+
+
+def test_run_flushes_data_on_shutdown(harvester, batch, client):
+    item = object()
+    harvester.record(item)
+
+    # Set shutdown event
+    harvester._shutdown.set()
+
+    assert not client.sent
+    harvester.run()
+    assert client.sent == [((item,), None)]
+
+
+def test_empty_items_not_sent(harvester, client):
+    # Set shutdown event
+    harvester._shutdown.set()
+
+    harvester.run()
+
+    # Send is never called if the batch is empty
+    assert not client.sent
+
+
+def test_harvester_terminates_at_shutdown(harvester, client):
+    # Set the interval high enough so that send is never called unless shutdown
+    # occurs
+    harvester.harvest_interval = 99999
+    harvester.start()
+
+    assert harvester.is_alive()
+
+    item = object()
+    harvester.record(item)
+
+    assert not client.sent
+    harvester.stop(0.1)
+    assert not harvester.is_alive()
+    assert client.sent == [((item,), None)]
+
+
+def test_harvester_handles_send_exception(caplog, batch):
+    # Cause an exception to be raised since send_batch doesn't exist on object
+    harvester = Harvester(object(), batch)
+
+    harvester.record(None)
+    harvester._shutdown.set()
+    harvester.run()
+
+    assert (
+        "newrelic_telemetry_sdk.harvester",
+        logging.ERROR,
+        "New Relic send_batch failed with an exception.",
+    ) in caplog.record_tuples
+
+
+def test_harvester_send_failed(caplog, harvester, client):
+    client.response.status = 500
+    client.response.ok = False
+
+    harvester.record(None)
+    harvester._shutdown.set()
+    harvester.run()
+
+    assert (
+        "newrelic_telemetry_sdk.harvester",
+        logging.ERROR,
+        "New Relic send_batch failed with status code: 500",
+    ) in caplog.record_tuples
+
+
+def test_harvest_timing(harvester, monkeypatch):
+    DELTA = 2
+    current_t = [0]
+    timeout = []
+
+    def _time():
+        # Move time forward by DELTA on every call
+        current_t[0] += DELTA
+        return current_t[0]
+
+    def _wait(t):
+        assert not timeout
+        timeout.append(t)
+        return True
+
+    monkeypatch.setattr(time, "time", _time, raising=True)
+    harvester._shutdown.wait = _wait
+
+    # First call should result in full timeout
+    assert harvester._wait_for_harvest()
+    assert timeout.pop() == harvester.harvest_interval
+
+    # Second call should account for the time between harvest intervals
+    assert harvester._wait_for_harvest()
+    assert timeout.pop() == (harvester.harvest_interval - DELTA)

--- a/tests/test_metric_batch.py
+++ b/tests/test_metric_batch.py
@@ -1,0 +1,78 @@
+# Copyright 2020 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from newrelic_telemetry_sdk.metric import GaugeMetric, CountMetric, SummaryMetric
+from newrelic_telemetry_sdk.metric_batch import MetricBatch
+
+
+@pytest.mark.parametrize("tags", (None, {"foo": "bar"}))
+def test_create_identity(tags):
+    metric = GaugeMetric("name", 1000, tags=tags)
+
+    expected_tags = frozenset(tags.items()) if tags else None
+    identity = MetricBatch.create_identity(metric)
+    assert len(identity) == 3
+    assert identity[0] is GaugeMetric
+    assert identity[1] == "name"
+    assert identity[2] == expected_tags
+
+
+@pytest.mark.parametrize(
+    "metric_a, metric_b, expected_value",
+    (
+        (GaugeMetric("name", 1), GaugeMetric("name", 2), 2),
+        (CountMetric("name", 1), CountMetric("name", 2), 3),
+        (
+            SummaryMetric.from_value("name", 1),
+            SummaryMetric.from_value("name", 2),
+            {"count": 2, "max": 2, "min": 1, "sum": 3},
+        ),
+    ),
+)
+def test_merge_metric(metric_a, metric_b, expected_value):
+    batch = MetricBatch()
+
+    batch.record(metric_a)
+    batch.record(metric_b)
+
+    assert metric_a.start_time_ms
+    assert metric_b.start_time_ms
+
+    assert len(batch._batch) == 1
+    _, metric = batch._batch.popitem()
+
+    assert metric.name == "name"
+    assert metric.value == expected_value
+    assert "timestamp" not in metric
+
+
+def test_flush():
+    metric = GaugeMetric("name", 1)
+    batch = MetricBatch()
+    batch.record(metric)
+
+    # Initialize with dummy timestamp to verify timestamp update
+    batch._interval_start = 0
+
+    metrics, common = batch.flush()
+
+    assert len(metrics) == 1
+
+    assert common["timestamp"] == 0
+    assert common["interval.ms"] > 0
+
+    # Verify internal state is updated
+    assert batch._interval_start > 0
+    assert batch._batch == {}

--- a/tests/test_span_batch.py
+++ b/tests/test_span_batch.py
@@ -1,0 +1,44 @@
+# Copyright 2020 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from newrelic_telemetry_sdk.span_batch import SpanBatch
+
+
+@pytest.mark.parametrize("tags", (None, {"foo": "bar"},))
+def test_span_batch_common_tags(tags):
+    batch = SpanBatch(tags)
+
+    if tags:
+        expected = {"attributes": tags}
+    else:
+        expected = None
+
+    _, common = batch.flush()
+    assert common == expected
+
+    if expected:
+        # Verify that we don't return the same objects twice
+        assert batch.flush()[1] is not common
+
+
+def test_span_batch_simple():
+    batch = SpanBatch()
+
+    # Verify that item is recorded and that flush clears out the batch
+    for _ in range(2):
+        item = object()
+        batch.record(item)
+
+        assert batch.flush()[0] == (item,)


### PR DESCRIPTION
This PR includes `Batch` and `Harvester` components that can be used to simplify aggregation, batching, and periodically sending to New Relic.

Batches provide a standard interface for aggregating and flushing data across different data types. This interface is used by the `Harvester` to forward data from batches to a client.

Documentation has been updated describing how to use these components.