### PR TITLE
Batch tags without a copy method raise an AttributeError.

### DIFF
--- a/src/newrelic_telemetry_sdk/metric_batch.py
+++ b/src/newrelic_telemetry_sdk/metric_batch.py
@@ -34,7 +34,7 @@ class MetricBatch(object):
         self._interval_start = int(time.time() * 1000.0)
         self._lock = self.LOCK_CLS()
         self._batch = {}
-        tags = tags and tags.copy() or {}
+        tags = tags and dict(tags)
         self._common = {}
         if tags:
             self._common["attributes"] = tags

--- a/src/newrelic_telemetry_sdk/span_batch.py
+++ b/src/newrelic_telemetry_sdk/span_batch.py
@@ -26,7 +26,7 @@ class SpanBatch(object):
     def __init__(self, tags=None):
         self._lock = self.LOCK_CLS()
         self._batch = []
-        tags = tags and tags.copy()
+        tags = tags and dict(tags)
         if tags:
             self._common = {"attributes": tags}
         else:

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -14,22 +14,7 @@
 
 import pytest
 from newrelic_telemetry_sdk.metric import Metric, CountMetric, SummaryMetric
-
-
-class CustomMapping(object):
-    def __getitem__(self, key):
-        if key == "foo":
-            return "bar"
-        raise KeyError(key)
-
-    def __iter__(self):
-        return iter(("foo",))
-
-    def __len__(self):
-        return 1
-
-    def keys(self):
-        return ("foo",)
+from utils import CustomMapping
 
 
 @pytest.mark.parametrize("method", (None, "from_value"))

--- a/tests/test_metric_batch.py
+++ b/tests/test_metric_batch.py
@@ -16,6 +16,7 @@ import time
 import pytest
 from newrelic_telemetry_sdk.metric import GaugeMetric, CountMetric, SummaryMetric
 from newrelic_telemetry_sdk.metric_batch import MetricBatch
+from utils import CustomMapping
 
 
 class VerifyLockMetricBatch(MetricBatch):
@@ -117,7 +118,7 @@ def test_different_metric(metric_a, metric_b):
     assert len(batch._internal_batch) == 2
 
 
-@pytest.mark.parametrize("tags", (None, {"foo": "bar"},))
+@pytest.mark.parametrize("tags", (None, {"foo": "bar"}, CustomMapping(),))
 def test_flush(monkeypatch, tags):
     metric = GaugeMetric("name", 1)
 
@@ -144,7 +145,7 @@ def test_flush(monkeypatch, tags):
     assert common["timestamp"] == 4000
     assert common["interval.ms"] == 12000
     if tags:
-        assert common["attributes"] == tags
+        assert common["attributes"] == dict(tags)
     else:
         assert "attributes" not in common
 

--- a/tests/test_span.py
+++ b/tests/test_span.py
@@ -14,22 +14,7 @@
 
 import pytest
 from newrelic_telemetry_sdk.span import Span
-
-
-class CustomMapping(object):
-    def __getitem__(self, key):
-        if key == "foo":
-            return "bar"
-        raise KeyError(key)
-
-    def __iter__(self):
-        return iter(("foo",))
-
-    def __len__(self):
-        return 1
-
-    def keys(self):
-        return ("foo",)
+from utils import CustomMapping
 
 
 def test_span_defaults(freeze_time):

--- a/tests/test_span_batch.py
+++ b/tests/test_span_batch.py
@@ -14,6 +14,7 @@
 
 import pytest
 from newrelic_telemetry_sdk.span_batch import SpanBatch
+from utils import CustomMapping
 
 
 class VerifyLockSpanBatch(SpanBatch):
@@ -46,12 +47,12 @@ class VerifyLockSpanBatch(SpanBatch):
         self._internal_common = value
 
 
-@pytest.mark.parametrize("tags", (None, {"foo": "bar"},))
+@pytest.mark.parametrize("tags", (None, {"foo": "bar"}, CustomMapping()))
 def test_span_batch_common_tags(tags):
     batch = VerifyLockSpanBatch(tags)
 
     if tags:
-        expected = {"attributes": tags}
+        expected = {"attributes": dict(tags)}
     else:
         expected = None
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,29 @@
+# Copyright 2019 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class CustomMapping(object):
+    def __getitem__(self, key):
+        if key == "foo":
+            return "bar"
+        raise KeyError(key)
+
+    def __iter__(self):
+        return iter(("foo",))
+
+    def __len__(self):
+        return 1
+
+    def keys(self):
+        return ("foo",)


### PR DESCRIPTION
Using a custom mapping class without a copy method for tags within batches resulted in a crash. Custom mapping classes are now properly converted to a dict for internal use by batches in the New Relic Python SDK.