### PR TITLE
Add support for event types.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,15 +12,14 @@ New Relic Telemetry SDK
 .. |black| image:: https://img.shields.io/badge/code%20style-black-000000.svg
     :target: https://github.com/psf/black
 
-``newrelic-telemetry-sdk-python`` provides a Python library for sending span and metric data
-into `New Relic <https://newrelic.com>`_ using the Python `urllib3 <https://urllib3.readthedocs.io>`_ library.
+``newrelic-telemetry-sdk-python`` provides a Python library for sending data into `New Relic <https://newrelic.com>`_ using the Python `urllib3 <https://urllib3.readthedocs.io>`_ library.
 
 The current SDK supports sending dimensional metrics to our `Metric API <https://docs.newrelic.com/docs/data-ingest-apis/get-data-new-relic/metric-api/introduction-metric-api>`_ and spans to our `Trace API <https://docs.newrelic.com/docs/understand-dependencies/distributed-tracing/trace-api/introduction-trace-api>`_.
 
 Why is this cool?
 -----------------
 
-Dimensional metrics and traces in New Relic! No agent required.
+Dimensional metrics, events, and traces in New Relic! No agent required.
 
 Our `Telemetry SDK <https://docs.newrelic.com/docs/data-ingest-apis/get-data-new-relic/new-relic-sdks/telemetry-sdks-send-custom-telemetry-data-new-relic>`_ tries to be helpful, so your job of sending telemetry data to New Relic can be done in the right way, easily. We've covered all of the basics for you so you can focus on writing feature code directly related to your business need or interest.
 
@@ -46,28 +45,6 @@ If that fails, download the library from its GitHub page and install it using:
 
     $ python setup.py install
 
-
-Reporting your first span
--------------------------
-
-Spans provide an easy way to time components of your code.
-The example code assumes you've set the following environment variables:
-
-* ``NEW_RELIC_INSERT_KEY``
-
-.. code-block:: python
-
-    import os
-    import time
-    from newrelic_telemetry_sdk import Span, SpanClient
-
-    with Span(name='sleep') as span:
-        time.sleep(0.5)
-
-    span_client = SpanClient(os.environ['NEW_RELIC_INSERT_KEY'])
-    response = span_client.send(span)
-    response.raise_for_status()
-    print('Span sleep sent successfully!')
 
 Reporting your first metric
 ---------------------------
@@ -120,12 +97,59 @@ The example code assumes you've set the following environment variables:
     response.raise_for_status()
     print("Sent metrics successfully!")
 
+Reporting your first event
+--------------------------
+
+Events represent a record of something that has occurred on a system being monitored.
+The example code assumes you've set the following environment variables:
+
+* ``NEW_RELIC_INSERT_KEY``
+
+.. code-block:: python
+
+    import os
+    import time
+    from newrelic_telemetry_sdk import Event, EventClient
+
+    # Record that a rate limit has been applied to an endpoint for an account
+    event = Event(
+        "RateLimit", {"path": "/v1/endpoint", "accountId": 1000, "rejectRatio": 0.1}
+    )
+
+    event_client = EventClient(os.environ["NEW_RELIC_INSERT_KEY"])
+    response = event_client.send(event)
+    response.raise_for_status()
+    print("Event sent successfully!")
+
+Reporting your first span
+-------------------------
+
+Spans provide an easy way to time components of your code.
+The example code assumes you've set the following environment variables:
+
+* ``NEW_RELIC_INSERT_KEY``
+
+.. code-block:: python
+
+    import os
+    import time
+    from newrelic_telemetry_sdk import Span, SpanClient
+
+    with Span(name='sleep') as span:
+        time.sleep(0.5)
+
+    span_client = SpanClient(os.environ['NEW_RELIC_INSERT_KEY'])
+    response = span_client.send(span)
+    response.raise_for_status()
+    print('Span sleep sent successfully!')
+
 Find and use data
 -----------------
 
 Tips on how to find and query your data in New Relic:
 
 * `Find metric data <https://docs.newrelic.com/docs/data-ingest-apis/get-data-new-relic/metric-api/introduction-metric-api#find-data>`_
+* `Find event data <https://docs.newrelic.com/docs/insights/insights-data-sources/custom-data/introduction-event-api#find-data>`_
 * `Find trace/span data <https://docs.newrelic.com/docs/understand-dependencies/distributed-tracing/trace-api/introduction-trace-api#view-data>`_
 
 For general querying information, see:

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -19,7 +19,9 @@ Batches are broken out by data type that they contain:
 +==========================================================+===========================================================================+
 | :class:`Metric <newrelic_telemetry_sdk.metric.Metric>`   | :class:`MetricBatch <newrelic_telemetry_sdk.metric_batch.MetricBatch>`    |
 +----------------------------------------------------------+---------------------------------------------------------------------------+
-| :class:`Span <newrelic_telemetry_sdk.span.Span>`         | :class:`SpanBatch <newrelic_telemetry_sdk.span_batch.SpanBatch>`          |
+| :class:`Event <newrelic_telemetry_sdk.span.Event>`       | :class:`EventBatch <newrelic_telemetry_sdk.batch.EventBatch>`             |
++----------------------------------------------------------+---------------------------------------------------------------------------+
+| :class:`Span <newrelic_telemetry_sdk.span.Span>`         | :class:`SpanBatch <newrelic_telemetry_sdk.batch.SpanBatch>`               |
 +----------------------------------------------------------+---------------------------------------------------------------------------+
 
 Example

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -15,31 +15,38 @@ New Relic HTTP Clients
 .. autoclass:: newrelic_telemetry_sdk.client.HTTPResponse()
     :members:
 
-Spans
------
-.. automodule:: newrelic_telemetry_sdk.span
-    :members:
-
 Metrics
 -------
 .. automodule:: newrelic_telemetry_sdk.metric
     :members:
     :undoc-members:
-    :show-inheritance:
+    :exclude-members: Metric
 
+Events
+-------
+.. automodule:: newrelic_telemetry_sdk.event
+    :members:
+
+Spans
+-----
+.. automodule:: newrelic_telemetry_sdk.span
+    :members:
 
 Batches
 -------
 .. automodule:: newrelic_telemetry_sdk.metric_batch
     :members:
+    :exclude-members: LOCK_CLS
 
-.. automodule:: newrelic_telemetry_sdk.span_batch
+.. automodule:: newrelic_telemetry_sdk.batch
     :members:
+    :exclude-members: Batch, LOCK_CLS
+    :inherited-members:
 
 Harvester
 ---------
 .. automodule:: newrelic_telemetry_sdk.harvester
     :members:
-    :exclude-members: LOCK_CLS, EVENT_CLS, run, daemon
+    :exclude-members: EVENT_CLS, run, daemon
     :show-inheritance:
     :inherited-members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,15 +1,14 @@
 newrelic-telemetry-sdk: Send data to New Relic!
 ===============================================
 
-``newrelic-telemetry-sdk`` provides a Python library for sending span and metric data
-into `New Relic <https://newrelic.com>`_ using the Python `urllib3 <https://urllib3.readthedocs.io>`_ library.
+``newrelic-telemetry-sdk`` provides a Python library for sending data into `New Relic <https://newrelic.com>`_ using the Python `urllib3 <https://urllib3.readthedocs.io>`_ library.
 
 The current SDK supports sending dimensional metrics to our `Metric API <https://docs.newrelic.com/docs/data-ingest-apis/get-data-new-relic/metric-api/introduction-metric-api>`_ and spans to our `Trace API <https://docs.newrelic.com/docs/understand-dependencies/distributed-tracing/trace-api/introduction-trace-api>`_.
 
 Why is this cool?
 -----------------
 
-Dimensional metrics and traces in New Relic! No agent required.
+Dimensional metrics, events, and traces in New Relic! No agent required.
 
 Our `Telemetry SDK <https://docs.newrelic.com/docs/data-ingest-apis/get-data-new-relic/new-relic-sdks/telemetry-sdks-send-custom-telemetry-data-new-relic>`_ tries to be helpful, so your job of sending telemetry data to New Relic can be done in the right way, easily. We've covered all of the basics for you so you can focus on writing feature code directly related to your business need or interest.
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -18,28 +18,6 @@ If that fails, download the library from its GitHub page and install it using:
     $ python setup.py install
 
 
-Reporting your first span
--------------------------
-
-Spans provide an easy way to time components of your code.
-The example code assumes you've set the following environment variables:
-
-* ``NEW_RELIC_INSERT_KEY``
-
-.. code-block:: python
-
-    import os
-    import time
-    from newrelic_telemetry_sdk import Span, SpanClient
-
-    with Span(name='sleep') as span:
-        time.sleep(0.5)
-
-    span_client = SpanClient(os.environ['NEW_RELIC_INSERT_KEY'])
-    response = span_client.send(span)
-    response.raise_for_status()
-    print('Span sleep sent successfully!')
-
 Reporting your first metric
 ---------------------------
 
@@ -91,12 +69,59 @@ The example code assumes you've set the following environment variables:
     response.raise_for_status()
     print("Sent metrics successfully!")
 
+Reporting your first event
+--------------------------
+
+Events represent a record of something that has occurred on a system being monitored.
+The example code assumes you've set the following environment variables:
+
+* ``NEW_RELIC_INSERT_KEY``
+
+.. code-block:: python
+
+    import os
+    import time
+    from newrelic_telemetry_sdk import Event, EventClient
+
+    # Record that a rate limit has been applied to an endpoint for an account
+    event = Event(
+        "RateLimit", {"path": "/v1/endpoint", "accountId": 1000, "rejectRatio": 0.1}
+    )
+
+    event_client = EventClient(os.environ["NEW_RELIC_INSERT_KEY"])
+    response = event_client.send(event)
+    response.raise_for_status()
+    print("Event sent successfully!")
+
+Reporting your first span
+-------------------------
+
+Spans provide an easy way to time components of your code.
+The example code assumes you've set the following environment variables:
+
+* ``NEW_RELIC_INSERT_KEY``
+
+.. code-block:: python
+
+    import os
+    import time
+    from newrelic_telemetry_sdk import Span, SpanClient
+
+    with Span(name='sleep') as span:
+        time.sleep(0.5)
+
+    span_client = SpanClient(os.environ['NEW_RELIC_INSERT_KEY'])
+    response = span_client.send(span)
+    response.raise_for_status()
+    print('Span sleep sent successfully!')
+
 Find and use data
 -----------------
 
 Tips on how to find and query your data in New Relic:
 
 * `Find metric data <https://docs.newrelic.com/docs/data-ingest-apis/get-data-new-relic/metric-api/introduction-metric-api#find-data>`_
+* `Find event data <https://docs.newrelic.com/docs/insights/insights-data-sources/custom-data/introduction-event-api#find-data>`_
 * `Find trace/span data <https://docs.newrelic.com/docs/understand-dependencies/distributed-tracing/trace-api/introduction-trace-api#view-data>`_
 
 For general querying information, see:

--- a/src/newrelic_telemetry_sdk/__init__.py
+++ b/src/newrelic_telemetry_sdk/__init__.py
@@ -12,11 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from newrelic_telemetry_sdk.client import SpanClient, MetricClient, HTTPError
+from newrelic_telemetry_sdk.client import (
+    SpanClient,
+    MetricClient,
+    EventClient,
+    HTTPError,
+)
 from newrelic_telemetry_sdk.span import Span
 from newrelic_telemetry_sdk.metric import GaugeMetric, CountMetric, SummaryMetric
+from newrelic_telemetry_sdk.event import Event
 from newrelic_telemetry_sdk.metric_batch import MetricBatch
-from newrelic_telemetry_sdk.span_batch import SpanBatch
+from newrelic_telemetry_sdk.batch import SpanBatch, EventBatch
 from newrelic_telemetry_sdk.harvester import Harvester
 
 try:
@@ -28,11 +34,14 @@ __all__ = (
     "HTTPError",
     "SpanClient",
     "MetricClient",
+    "EventClient",
     "Span",
     "GaugeMetric",
     "CountMetric",
     "SummaryMetric",
+    "Event",
     "MetricBatch",
     "SpanBatch",
+    "EventBatch",
     "Harvester",
 )

--- a/src/newrelic_telemetry_sdk/batch.py
+++ b/src/newrelic_telemetry_sdk/batch.py
@@ -69,18 +69,10 @@ class SpanBatch(Batch):
 
 
 class EventBatch(Batch):
-    """Aggregates events, providing a record / flush interface.
+    """Aggregates events, providing a record / flush interface."""
 
-    :param tags: (optional) A dictionary of tags to attach to all flushes.
-    :type tags: dict
-    """
-
-    def __init__(self, tags=None):
-        super(EventBatch, self).__init__(tags)
-        if tags:
-            # Events are currently a flat structure, so there's no nesting of
-            # user attributes.
-            self._common = dict(tags)
+    def __init__(self):
+        super(EventBatch, self).__init__()
 
     def flush(self):
         """Flush all items from the batch
@@ -92,7 +84,5 @@ class EventBatch(Batch):
         :returns: A tuple of (items,)
         :rtype: tuple
         """
-        items, common = super(EventBatch, self).flush()
-        if common:
-            items = tuple(dict(common, **item) for item in items)
+        items, _ = super(EventBatch, self).flush()
         return (items,)

--- a/src/newrelic_telemetry_sdk/event.py
+++ b/src/newrelic_telemetry_sdk/event.py
@@ -1,0 +1,52 @@
+# Copyright 2019 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+
+
+class Event(dict):
+    """An event represented in New Relic Insights
+
+    :param event_type: The type of event to report
+    :type event_type: str
+    :param tags: (optional) A set of tags that can be used to filter this
+        event in the New Relic UI.
+    :type tags: dict
+    :param timestamp_ms: (optional) A unix timestamp in milliseconds
+        representing the timestamp in ms at which the event occurred. Defaults to
+        time.time() * 1000
+    :type timestamp_ms: int
+    """
+
+    def __init__(self, event_type, tags=None, timestamp_ms=None):
+        timestamp = int(timestamp_ms or (time.time() * 1000))
+        if tags:
+            self.update(tags)
+        super(Event, self).__init__(eventType=event_type, timestamp=timestamp)
+
+    def copy(self):
+        cls = type(self)
+        d = cls.__new__(cls)
+        d.update(self)
+        return d
+
+    @property
+    def event_type(self):
+        """Event Type"""
+        return self["eventType"]
+
+    @property
+    def timestamp_ms(self):
+        """Event Timestamp"""
+        return self["timestamp"]

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -74,21 +74,3 @@ def test_batch_simple(batch_cls):
         batch.record(item)
 
         assert batch.flush()[0] == (item,)
-
-
-@pytest.mark.parametrize("tags", (None, {"foo": "bar"}, {"boo": "baz"}))
-def test_event_batch_common_tags(tags):
-    batch = EventBatch(tags)
-
-    expected = item = {"foo": "foo"}
-    if tags:
-        expected = dict(tags)
-        expected.update(item)
-
-    for _ in range(2):
-        batch.record(item)
-
-        result = batch.flush()
-        items = result[0]
-
-        assert items == (expected,)

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -1,0 +1,68 @@
+# Copyright 2019 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from newrelic_telemetry_sdk.event import Event
+
+
+def test_event_defaults(freeze_time):
+    event = Event("event")
+    assert event == {
+        "eventType": "event",
+        "timestamp": 2000,
+    }
+    assert type(event["timestamp"]) is int
+
+
+@pytest.mark.parametrize(
+    "arg_name,arg_value,event_key,event_value",
+    (
+        ("tags", {"foo": "bar"}, ("foo",), "bar"),
+        ("timestamp_ms", 1000, ("timestamp",), 1000),
+    ),
+)
+def test_event_optional(arg_name, arg_value, event_key, event_value):
+    kwargs = {arg_name: arg_value}
+    event = Event("event", **kwargs)
+
+    value = event
+    for key in event_key:
+        value = value[key]
+
+    assert value == event_value
+    assert type(value) is type(event_value)
+
+
+@pytest.mark.parametrize(
+    "attribute_name,attribute_value",
+    (("event_type", "event"), ("timestamp_ms", 1000),),
+)
+def test_event_attributes(attribute_name, attribute_value):
+    event = Event("event", timestamp_ms=1000)
+    value = getattr(event, attribute_name)
+    assert value == attribute_value
+    assert type(value) is type(attribute_value)
+
+
+def test_event_copy():
+    original = Event("event")
+    copy = original.copy()
+    assert copy == original
+    assert copy is not original
+
+
+def test_intrinsics_override_user_attributes():
+    tags = {"eventType": "illegal"}
+    event = Event("event", tags)
+    assert event["eventType"] == "event"


### PR DESCRIPTION
This PR implements custom event types, as requested in #13 .

Within this PR are:
* Client/Batch types for Events
* Documentation updates showcasing the event functionality (including docstrings and examples)
* Testing and verification for event behavior (including support for common tags/custom attributes in batches, which currently has no backend support)