### PR TITLE
Deprecate use of compression_threshold.

### DIFF
--- a/src/newrelic_telemetry_sdk/client.py
+++ b/src/newrelic_telemetry_sdk/client.py
@@ -14,6 +14,7 @@
 
 import json
 import urllib3
+import warnings
 import zlib
 
 try:
@@ -24,6 +25,8 @@ except ImportError:  # pragma: no cover
 USER_AGENT = "NewRelic-Python-TelemetrySDK/{}".format(__version__)
 
 __all__ = ("SpanClient", "MetricClient", "HTTPError", "HTTPResponse")
+
+DEFAULT_COMPRESSION = object()
 
 
 class HTTPError(ValueError):
@@ -75,8 +78,8 @@ class Client(object):
     :type insert_key: str
     :param host: (optional) Override the host for the client.
     :type host: str
-    :param compression_threshold: (optional) Compress if number of bytes in
-        payload is above this threshold. (Default: 64K)
+    :param compression_threshold: (optional-deprecated) Compress if number of
+        bytes in payload is above this threshold. (Default: 64K)
     :type compression_threshold: int
 
     Usage::
@@ -96,9 +99,20 @@ class Client(object):
         keep_alive=True, accept_encoding=True, user_agent=USER_AGENT
     )
 
-    def __init__(self, insert_key, host=None, compression_threshold=64 * 1024):
+    def __init__(
+        self, insert_key, host=None, compression_threshold=DEFAULT_COMPRESSION
+    ):
         host = host or self.HOST
-        self.compression_threshold = compression_threshold
+        if compression_threshold is not DEFAULT_COMPRESSION:
+            warnings.warn(
+                "The compression_threshold option will be removed in an "
+                "upcoming release. All payloads will be gzip compressed in a "
+                "future release.",
+                DeprecationWarning,
+            )
+            self.compression_threshold = compression_threshold
+        else:
+            self.compression_threshold = 64 * 1024
         headers = self.HEADERS.copy()
         headers.update(
             {
@@ -185,8 +199,8 @@ class SpanClient(Client):
     :type insert_key: str
     :param host: (optional) Override the host for the span API endpoint.
     :type host: str
-    :param compression_threshold: (optional) Compress if number of bytes in
-        payload is above this threshold. (Default: 64K)
+    :param compression_threshold: (optional-deprecated) Compress if number of
+        bytes in payload is above this threshold. (Default: 64K)
     :type compression_threshold: int
 
     Usage::
@@ -212,8 +226,8 @@ class MetricClient(Client):
     :param host: (optional) Override the host for the metric API
         endpoint.
     :type host: str
-    :param compression_threshold: (optional) Compress if number of bytes in
-        payload is above this threshold. (Default: 64K)
+    :param compression_threshold: (optional-deprecated) Compress if number of
+        bytes in payload is above this threshold. (Default: 64K)
     :type compression_threshold: int
 
     Usage::
@@ -239,8 +253,8 @@ class EventClient(Client):
     :param host: (optional) Override the host for the event API
         endpoint.
     :type host: str
-    :param compression_threshold: (optional) Compress if number of bytes in
-        payload is above this threshold. (Default: 64K)
+    :param compression_threshold: (optional-deprecated) Compress if number of
+        bytes in payload is above this threshold. (Default: 64K)
     :type compression_threshold: int
 
     Usage::

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -278,6 +278,7 @@ def validate_event_request(request, items):
         ),
     ),
 )
+@pytest.mark.filterwarnings("ignore:.*compression_threshold.*:DeprecationWarning")
 def test_span_endpoint_compression(compressed, span_client):
     response = span_client.send(SPAN)
     request = response.request
@@ -297,6 +298,7 @@ def test_span_endpoint_compression(compressed, span_client):
         ),
     ),
 )
+@pytest.mark.filterwarnings("ignore:.*compression_threshold.*:DeprecationWarning")
 def test_metric_endpoint_compression(compressed, metric_client):
     response = metric_client.send(METRIC)
     request = response.request
@@ -316,6 +318,7 @@ def test_metric_endpoint_compression(compressed, metric_client):
         ),
     ),
 )
+@pytest.mark.filterwarnings("ignore:.*compression_threshold.*:DeprecationWarning")
 def test_event_endpoint_compression(compressed, event_client):
     response = event_client.send(EVENT)
     request = response.request
@@ -384,6 +387,7 @@ def test_defaults(cls, host):
         pytest.param(marks=pytest.mark.client_args(compression_threshold=float("inf"))),
     ),
 )
+@pytest.mark.filterwarnings("ignore:.*compression_threshold.*:DeprecationWarning")
 def test_metric_add_version_info(metric_client):
     metric_client.add_version_info("foo", "0.1")
     metric_client.add_version_info("bar", "0.2")
@@ -401,6 +405,7 @@ def test_metric_add_version_info(metric_client):
         pytest.param(marks=pytest.mark.client_args(compression_threshold=float("inf"))),
     ),
 )
+@pytest.mark.filterwarnings("ignore:.*compression_threshold.*:DeprecationWarning")
 def test_span_add_version_info(span_client):
     span_client.add_version_info("foo", "0.1")
     span_client.add_version_info("bar", "0.2")
@@ -418,6 +423,7 @@ def test_span_add_version_info(span_client):
         pytest.param(marks=pytest.mark.client_args(compression_threshold=float("inf"))),
     ),
 )
+@pytest.mark.filterwarnings("ignore:.*compression_threshold.*:DeprecationWarning")
 def test_event_add_version_info(event_client):
     event_client.add_version_info("foo", "0.1")
     event_client.add_version_info("bar", "0.2")


### PR DESCRIPTION
The SDK should transition to always using gzip compression for payloads rather than making it configurable.