### PR TITLE
Add port override.

### DIFF
--- a/src/newrelic_telemetry_sdk/client.py
+++ b/src/newrelic_telemetry_sdk/client.py
@@ -75,6 +75,9 @@ class Client(object):
     :type insert_key: str
     :param host: (optional) Override the host for the client.
     :type host: str
+    :param port: (optional) Override the port for the client.
+        Default: 443
+    :type port: int
 
     Usage::
 
@@ -92,7 +95,7 @@ class Client(object):
         keep_alive=True, accept_encoding=True, user_agent=USER_AGENT
     )
 
-    def __init__(self, insert_key, host=None):
+    def __init__(self, insert_key, host=None, port=443):
         host = host or self.HOST
         headers = self.HEADERS.copy()
         headers.update(
@@ -106,7 +109,7 @@ class Client(object):
             total=False, connect=None, read=None, redirect=0, status=None
         )
         self._pool = self.POOL_CLS(
-            host=host, port=443, retries=retries, headers=headers, strict=True
+            host=host, port=port, retries=retries, headers=headers, strict=True
         )
 
     def add_version_info(self, product, product_version):
@@ -174,6 +177,9 @@ class SpanClient(Client):
     :type insert_key: str
     :param host: (optional) Override the host for the span API endpoint.
     :type host: str
+    :param port: (optional) Override the port for the client.
+        Default: 443
+    :type port: int
 
     Usage::
 
@@ -198,6 +204,9 @@ class MetricClient(Client):
     :param host: (optional) Override the host for the metric API
         endpoint.
     :type host: str
+    :param port: (optional) Override the port for the client.
+        Default: 443
+    :type port: int
 
     Usage::
 
@@ -222,6 +231,9 @@ class EventClient(Client):
     :param host: (optional) Override the host for the event API
         endpoint.
     :type host: str
+    :param port: (optional) Override the port for the client.
+        Default: 443
+    :type port: int
 
     Usage::
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -317,6 +317,7 @@ def test_event_endpoint_batch(event_client):
 )
 def test_defaults(cls, host):
     assert cls.HOST == host
+    assert cls(None)._pool.port == 443
 
 
 def test_metric_add_version_info(metric_client):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -320,6 +320,11 @@ def test_defaults(cls, host):
     assert cls(None)._pool.port == 443
 
 
+@pytest.mark.parametrize("cls", (SpanClient, MetricClient, EventClient))
+def test_port_override(cls):
+    assert cls(None, port=8000)._pool.port == 8000
+
+
 def test_metric_add_version_info(metric_client):
     metric_client.add_version_info("foo", "0.1")
     metric_client.add_version_info("bar", "0.2")


### PR DESCRIPTION
Allow users to override the port for `SpanClient`, `EventClient`, and `MetricClient`.

### Example

```python
import os
import time
from newrelic_telemetry_sdk import Span, SpanClient

with Span(name='sleep') as span:
    time.sleep(0.5)

span_client = SpanClient(os.environ['NEW_RELIC_INSERT_KEY'], port=8000)
response = span_client.send(span)
response.raise_for_status()
print('Span sleep sent successfully!')
```