### PR TITLE
Fix harvester crash when using event client.

### DIFF
--- a/src/newrelic_telemetry_sdk/harvester.py
+++ b/src/newrelic_telemetry_sdk/harvester.py
@@ -61,11 +61,11 @@ class Harvester(threading.Thread):
         self._harvest_interval_start = 0
         self._shutdown = self.EVENT_CLS()
 
-    def _send(self, items, common=None):
+    def _send(self, items, *args):
         """Send items through the harvester client, handling any exceptions"""
         if items:
             try:
-                response = self._client.send_batch(items, common=common)
+                response = self._client.send_batch(items, *args)
                 if not response.ok:
                     _logger.error(
                         "New Relic send_batch failed with status code: %r",

--- a/tests/test_harvester.py
+++ b/tests/test_harvester.py
@@ -82,7 +82,8 @@ def test_run_once(harvester, client):
     item = object()
     harvester.record(item)
 
-    harvester.run()
+    harvester.start()
+    harvester.stop(timeout=0.1)
 
     assert client.sent == [((item,), None)]
 
@@ -95,7 +96,8 @@ def test_run_flushes_data_on_shutdown(harvester, batch, client):
     harvester._shutdown.set()
 
     assert not client.sent
-    harvester.run()
+    harvester.start()
+    harvester.stop(timeout=0.1)
     assert client.sent == [((item,), None)]
 
 
@@ -103,7 +105,8 @@ def test_empty_items_not_sent(harvester, client):
     # Set shutdown event
     harvester._shutdown.set()
 
-    harvester.run()
+    harvester.start()
+    harvester.stop(timeout=0.1)
 
     # Send is never called if the batch is empty
     assert not client.sent
@@ -132,7 +135,8 @@ def test_harvester_handles_send_exception(caplog, batch):
 
     harvester.record(None)
     harvester._shutdown.set()
-    harvester.run()
+    harvester.start()
+    harvester.stop(timeout=0.1)
 
     assert (
         "newrelic_telemetry_sdk.harvester",
@@ -147,7 +151,8 @@ def test_harvester_send_failed(caplog, harvester, client):
 
     harvester.record(None)
     harvester._shutdown.set()
-    harvester.run()
+    harvester.start()
+    harvester.stop(timeout=0.1)
 
     assert (
         "newrelic_telemetry_sdk.harvester",

--- a/tests/test_harvester.py
+++ b/tests/test_harvester.py
@@ -47,30 +47,43 @@ class FakeClient(object):
         return self.response
 
 
-@pytest.fixture
-def batch():
-    return FakeBatch()
+class ExceptionalClient(object):
+    def send_batch(self, *args, **kwargs):
+        raise RuntimeError("oops")
+
+
+class FakeEventBatch(FakeBatch):
+    def flush(self):
+        results = super(FakeEventBatch, self).flush()
+        return results[:1]
+
+
+class FakeEventClient(FakeClient):
+    def send_batch(self, items):
+        return super(FakeEventClient, self).send_batch(items)
+
+
+@pytest.fixture(params=((FakeClient, FakeBatch), (FakeEventClient, FakeEventBatch)))
+def harvester_args(request):
+    client_cls, event_cls = request.param
+    return client_cls(), event_cls()
 
 
 @pytest.fixture
-def client():
-    return FakeClient()
-
-
-@pytest.fixture
-def harvester(client, batch):
-    harvester = Harvester(client, batch)
+def harvester(harvester_args):
+    harvester = Harvester(*harvester_args)
     return harvester
 
 
-def test_record(harvester, batch):
+def test_record(harvester):
     item = object()
     harvester.record(item)
-    assert batch.contents == [item]
+    assert harvester._batch.contents == [item]
 
 
-def test_run_once(harvester, client):
+def test_run_once(harvester):
     harvester.harvest_interval = 0
+    client = harvester._client
     send_batch = client.send_batch
 
     def shutdown_after_send(*args, **kwargs):
@@ -88,7 +101,9 @@ def test_run_once(harvester, client):
     assert client.sent == [((item,), None)]
 
 
-def test_run_flushes_data_on_shutdown(harvester, batch, client):
+def test_run_flushes_data_on_shutdown(harvester):
+    client = harvester._client
+
     item = object()
     harvester.record(item)
 
@@ -101,7 +116,9 @@ def test_run_flushes_data_on_shutdown(harvester, batch, client):
     assert client.sent == [((item,), None)]
 
 
-def test_empty_items_not_sent(harvester, client):
+def test_empty_items_not_sent(harvester):
+    client = harvester._client
+
     # Set shutdown event
     harvester._shutdown.set()
 
@@ -112,7 +129,9 @@ def test_empty_items_not_sent(harvester, client):
     assert not client.sent
 
 
-def test_harvester_terminates_at_shutdown(harvester, client):
+def test_harvester_terminates_at_shutdown(harvester):
+    client = harvester._client
+
     # Set the interval high enough so that send is never called unless shutdown
     # occurs
     harvester.harvest_interval = 99999
@@ -129,7 +148,9 @@ def test_harvester_terminates_at_shutdown(harvester, client):
     assert client.sent == [((item,), None)]
 
 
-def test_harvester_handles_send_exception(caplog, batch):
+def test_harvester_handles_send_exception(caplog):
+    batch = FakeBatch()
+
     # Cause an exception to be raised since send_batch doesn't exist on object
     harvester = Harvester(object(), batch)
 
@@ -145,7 +166,8 @@ def test_harvester_handles_send_exception(caplog, batch):
     ) in caplog.record_tuples
 
 
-def test_harvester_send_failed(caplog, harvester, client):
+def test_harvester_send_failed(caplog, harvester):
+    client = harvester._client
     client.response.status = 500
     client.response.ok = False
 


### PR DESCRIPTION
Fixes a crash when using the harvester with `EventClient`/`EventBatch`. See #23 for details.