### PR TITLE
Update metric batch interface.

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -34,9 +34,7 @@ Example
     metric_batch = MetricBatch()
 
     # Record that there have been 5 errors
-    # Interval is not required since the metric will be placed in a batch!
-    errors = CountMetric(name="errors", value=5)
-    metric_batch.record(errors)
+    metric_batch.record_count("errors", 5)
 
     # Calling flush will clear the batch and reset the interval start time
     items, common = metric_batch.flush()
@@ -50,8 +48,6 @@ Harvester
 A :class:`Harvester <newrelic_telemetry_sdk.harvester.Harvester>` flushes a batch and sends data through a client at a fixed harvest interval.
 
 The :class:`Harvester <newrelic_telemetry_sdk.harvester.Harvester>` class is a :class:`threading.Thread` and has :meth:`start <newrelic_telemetry_sdk.harvester.Harvester.start>` and :meth:`stop <newrelic_telemetry_sdk.harvester.Harvester.stop>` methods.
-
-The :meth:`record <newrelic_telemetry_sdk.harvester.Harvester.record>` method intentionally has the same signature as a batch's record method. For all intents and purposes, the harvester can be treated as a batch that will be periodically flushed and sent to New Relic.
 
 Example
 ^^^^^^^
@@ -77,5 +73,4 @@ The example code assumes you've set the following environment variables:
 
     # Data is now recorded through the harvester
     # The data will buffer and send every 5 seconds or at process exit
-    temperature = GaugeMetric("temperature", 78.6, {"units": "Farenheit"})
-    metric_harvester.record(temperature)
+    metric_harvester.record_gauge("temperature", 78.6, {"units": "Farenheit"})

--- a/src/newrelic_telemetry_sdk/harvester.py
+++ b/src/newrelic_telemetry_sdk/harvester.py
@@ -15,7 +15,6 @@
 import logging
 import time
 import threading
-import warnings
 
 _logger = logging.getLogger(__name__)
 
@@ -56,9 +55,9 @@ class Harvester(threading.Thread):
     def __init__(self, client, batch, harvest_interval=5):
         super(Harvester, self).__init__()
         self.daemon = True
+        self.batch = batch
         self.harvest_interval = harvest_interval
         self._client = client
-        self.batch = batch
         self._harvest_interval_start = 0
         self._shutdown = self.EVENT_CLS()
 
@@ -72,6 +71,7 @@ class Harvester(threading.Thread):
                         "New Relic send_batch failed with status code: %r",
                         response.status,
                     )
+                return response
             except Exception:
                 _logger.exception("New Relic send_batch failed with an exception.")
 
@@ -104,14 +104,7 @@ class Harvester(threading.Thread):
 
         :param item: A metric or span to be merged into a batch.
         """
-        warnings.warn(
-            (
-                "Harvester.record will be removed in a future release. "
-                "Please use Harvester.batch.record or batch.record."
-            ),
-            DeprecationWarning,
-        )
-        self.batch.record(item)
+        self._batch.record(item)
 
     def stop(self, timeout=None):
         """Terminate the harvester.

--- a/src/newrelic_telemetry_sdk/harvester.py
+++ b/src/newrelic_telemetry_sdk/harvester.py
@@ -96,16 +96,6 @@ class Harvester(threading.Thread):
         # deallocate batch
         self.batch = self._client = None
 
-    def record(self, item):
-        """Add an item to the batch to be harvested
-
-        Calling record with an item will merge it into the batch maintained by
-        this harvester.
-
-        :param item: A metric or span to be merged into a batch.
-        """
-        self._batch.record(item)
-
     def stop(self, timeout=None):
         """Terminate the harvester.
 

--- a/src/newrelic_telemetry_sdk/harvester.py
+++ b/src/newrelic_telemetry_sdk/harvester.py
@@ -92,6 +92,9 @@ class Harvester(threading.Thread):
         # Flush any remaining data and send it prior to shutting down
         self._send(*self.batch.flush())
 
+        # Close client
+        self._client.close()
+
         # Clear all references to client and batch to close connections and
         # deallocate batch
         self.batch = self._client = None


### PR DESCRIPTION
This PR updates the metric batch interfaces to use individual `record_*` methods for each metric type. The reason for this is to support aggregation of metric "values" rather than actual complete metric objects.

The original thought process for having a unified `record` interface for batches was so that batch flush and client send could happen on the same thread to avoid a lock. Since we have made batches thread safe, it's no longer necessary to keep the batch interfaces uniform.

By allowing for separate interfaces for metric batches, the aggregations being done are more explicit, and in the case of `GaugeMetric`, more correct.