### PR TITLE
Add a close interface for clients.

### DIFF
--- a/src/newrelic_telemetry_sdk/client.py
+++ b/src/newrelic_telemetry_sdk/client.py
@@ -85,6 +85,7 @@ class Client(object):
         >>> insert_key = os.environ.get("NEW_RELIC_INSERT_KEY", "")
         >>> client = Client(insert_key, host="metric-api.newrelic.com")
         >>> response = client.send({})
+        >>> client.close()
     """
 
     POOL_CLS = HTTPSConnectionPool
@@ -125,6 +126,10 @@ class Client(object):
         """
         product_ua_header = " {}/{}".format(product, product_version)
         self._pool.headers["user-agent"] += product_ua_header
+
+    def close(self):
+        """Close all open connections and disable internal connection pool."""
+        self._pool.close()
 
     @staticmethod
     def _compress_payload(payload):
@@ -187,6 +192,7 @@ class SpanClient(Client):
         >>> insert_key = os.environ.get("NEW_RELIC_INSERT_KEY", "")
         >>> span_client = SpanClient(insert_key)
         >>> response = span_client.send({})
+        >>> span_client.close()
     """
 
     HOST = "trace-api.newrelic.com"
@@ -214,6 +220,7 @@ class MetricClient(Client):
         >>> insert_key = os.environ.get("NEW_RELIC_INSERT_KEY", "")
         >>> metric_client = MetricClient(insert_key)
         >>> response = metric_client.send({})
+        >>> metric_client.close()
     """
 
     HOST = "metric-api.newrelic.com"
@@ -241,6 +248,7 @@ class EventClient(Client):
         >>> insert_key = os.environ.get("NEW_RELIC_INSERT_KEY", "")
         >>> event_client = EventClient(insert_key)
         >>> response = event_client.send({})
+        >>> event_client.close()
     """
 
     HOST = "insights-collector.newrelic.com"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -132,7 +132,8 @@ def span_client(request, monkeypatch):
         client = SpanClient(insert_key, host)
 
     assert client._pool.port == 443
-    return client
+    yield client
+    client.close()
 
 
 @pytest.fixture
@@ -157,7 +158,8 @@ def metric_client(request, monkeypatch):
         client = MetricClient(insert_key, host)
 
     assert client._pool.port == 443
-    return client
+    yield client
+    client.close()
 
 
 @pytest.fixture
@@ -182,7 +184,8 @@ def event_client(request, monkeypatch):
         client = EventClient(insert_key, host)
 
     assert client._pool.port == 443
-    return client
+    yield client
+    client.close()
 
 
 def ensure_str(s):
@@ -356,3 +359,18 @@ def test_event_add_version_info(event_client):
 
     user_agent = request.headers["user-agent"]
     assert user_agent.endswith(" foo/0.1 bar/0.2"), user_agent
+
+
+def test_metric_client_close(metric_client):
+    metric_client.close()
+    assert metric_client._pool.pool is None
+
+
+def test_event_client_close(event_client):
+    event_client.close()
+    assert event_client._pool.pool is None
+
+
+def test_span_client_close(span_client):
+    span_client.close()
+    assert span_client._pool.pool is None


### PR DESCRIPTION
This PR adds a `Client.close` interface, allowing for connections to be explicitly closed before the client is disposed of.