### PR TITLE
Add deprecation warnings for removed interfaces.

### DIFF
--- a/src/newrelic_telemetry_sdk/metric.py
+++ b/src/newrelic_telemetry_sdk/metric.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import time
+import warnings
 
 
 class Metric(dict):
@@ -88,6 +89,13 @@ class Metric(dict):
 
     @classmethod
     def from_value(cls, name, value, tags=None, interval_ms=None, end_time_ms=None):
+        warnings.warn(
+            (
+                "Metric.from_value will be removed in a future release. "
+                "Please use the contructor for the metric you are creating."
+            ),
+            DeprecationWarning,
+        )
         return cls(
             name=name,
             value=value,
@@ -189,7 +197,8 @@ class SummaryMetric(Metric):
     Usage::
 
         >>> from newrelic_telemetry_sdk import SummaryMetric
-        >>> metric = SummaryMetric.from_value('response_time', 0.2)
+        >>> metric = SummaryMetric('response_time',
+        ...     count=1, sum=0.2, min=0.2, max=0.2, interval_ms=1)
         >>> sorted(metric.value.items())
         [('count', 1), ('max', 0.2), ('min', 0.2), ('sum', 0.2)]
     """
@@ -219,6 +228,13 @@ class SummaryMetric(Metric):
             the end time of the metric. Defaults to time.time() * 1000
         :type end_time_ms: int
         """
+        warnings.warn(
+            (
+                "Metric.from_value will be removed in a future release. "
+                "Please use the contructor for the metric you are creating."
+            ),
+            DeprecationWarning,
+        )
         return cls(
             name=name,
             count=1,

--- a/tests/test_harvester.py
+++ b/tests/test_harvester.py
@@ -75,10 +75,11 @@ def harvester(harvester_args):
     return harvester
 
 
+@pytest.mark.filterwarnings("ignore:.*Harvester.record.*:DeprecationWarning")
 def test_record(harvester):
     item = object()
     harvester.record(item)
-    assert harvester._batch.contents == [item]
+    assert harvester.batch.contents == [item]
 
 
 def test_run_once(harvester):
@@ -93,7 +94,7 @@ def test_run_once(harvester):
 
     client.send_batch = shutdown_after_send
     item = object()
-    harvester.record(item)
+    harvester.batch.record(item)
 
     harvester.start()
     harvester.stop(timeout=0.1)
@@ -105,7 +106,7 @@ def test_run_flushes_data_on_shutdown(harvester):
     client = harvester._client
 
     item = object()
-    harvester.record(item)
+    harvester.batch.record(item)
 
     # Set shutdown event
     harvester._shutdown.set()
@@ -140,7 +141,7 @@ def test_harvester_terminates_at_shutdown(harvester):
     assert harvester.is_alive()
 
     item = object()
-    harvester.record(item)
+    harvester.batch.record(item)
 
     assert not client.sent
     harvester.stop(0.1)
@@ -154,7 +155,7 @@ def test_harvester_handles_send_exception(caplog):
     # Cause an exception to be raised since send_batch doesn't exist on object
     harvester = Harvester(object(), batch)
 
-    harvester.record(None)
+    harvester.batch.record(None)
     harvester._shutdown.set()
     harvester.start()
     harvester.stop(timeout=0.1)
@@ -171,7 +172,7 @@ def test_harvester_send_failed(caplog, harvester):
     client.response.status = 500
     client.response.ok = False
 
-    harvester.record(None)
+    harvester.batch.record(None)
     harvester._shutdown.set()
     harvester.start()
     harvester.stop(timeout=0.1)

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -17,6 +17,7 @@ from newrelic_telemetry_sdk.metric import Metric, CountMetric, SummaryMetric
 from utils import CustomMapping
 
 
+@pytest.mark.filterwarnings("ignore:.*Metric.from_value.*:DeprecationWarning")
 @pytest.mark.parametrize("method", (None, "from_value"))
 def test_metric_defaults(method, freeze_time):
     new = Metric
@@ -111,6 +112,7 @@ def test_metric_copy():
     assert copy is not original
 
 
+@pytest.mark.filterwarnings("ignore:.*Metric.from_value.*:DeprecationWarning")
 def test_summary_metric_from_value():
     metric = SummaryMetric.from_value("foo", 3)
     assert len(metric["value"]) == 4

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -33,6 +33,7 @@ def test_metric_defaults(method, freeze_time):
     assert "interval.ms" not in metric
 
 
+@pytest.mark.filterwarnings("ignore:.*interval_ms.*:DeprecationWarning")
 def test_count_metric_defaults(freeze_time):
     metric = CountMetric("name", 0)
     assert metric["type"] == "count"
@@ -45,6 +46,7 @@ def test_count_metric_defaults(freeze_time):
     assert "interval.ms" not in metric
 
 
+@pytest.mark.filterwarnings("ignore:.*interval_ms.*:DeprecationWarning")
 def test_summary_metric_defaults(freeze_time):
     metric = SummaryMetric("name", 0, 0, 0, 0)
     assert metric["type"] == "summary"

--- a/tests/test_metric_batch.py
+++ b/tests/test_metric_batch.py
@@ -78,8 +78,8 @@ def test_create_identity(tags):
         (GaugeMetric("name", 1), GaugeMetric("name", 2), 2),
         (CountMetric("name", 1), CountMetric("name", 2), 3),
         (
-            SummaryMetric.from_value("name", 1),
-            SummaryMetric.from_value("name", 2),
+            SummaryMetric("name", 1, 1, 1, 1),
+            SummaryMetric("name", 1, 2, 2, 2),
             {"count": 2, "max": 2, "min": 1, "sum": 3},
         ),
     ),


### PR DESCRIPTION
There are a couple of proposed interface changes to be made. Prior to changing those interfaces, we must add deprecation warnings for those interfaces.

Overview of changes:

* Metric.from_value is removed, replaced with metric constructor
* CountMetric / SummaryMetric interval_ms must be specified
* Harvester.record is removed and replaced with Harvester.batch.record (or simply Batch.record)
* MetricBatch.record method is removed, replaced with MetricBatch.record_gauge, MetricBatch.record_count, MetricBatch.record_summary