### PR TITLE
Make client public on the harvester.

### DIFF
--- a/src/newrelic_telemetry_sdk/harvester.py
+++ b/src/newrelic_telemetry_sdk/harvester.py
@@ -55,9 +55,9 @@ class Harvester(threading.Thread):
     def __init__(self, client, batch, harvest_interval=5):
         super(Harvester, self).__init__()
         self.daemon = True
+        self.client = client
         self.batch = batch
         self.harvest_interval = harvest_interval
-        self._client = client
         self._harvest_interval_start = 0
         self._shutdown = self.EVENT_CLS()
 
@@ -65,7 +65,7 @@ class Harvester(threading.Thread):
         """Send items through the harvester client, handling any exceptions"""
         if items:
             try:
-                response = self._client.send_batch(items, *args)
+                response = self.client.send_batch(items, *args)
                 if not response.ok:
                     _logger.error(
                         "New Relic send_batch failed with status code: %r",
@@ -93,11 +93,11 @@ class Harvester(threading.Thread):
         self._send(*self.batch.flush())
 
         # Close client
-        self._client.close()
+        self.client.close()
 
         # Clear all references to client and batch to close connections and
         # deallocate batch
-        self.batch = self._client = None
+        self.batch = self.client = None
 
     def stop(self, timeout=None):
         """Terminate the harvester.

--- a/tests/test_harvester.py
+++ b/tests/test_harvester.py
@@ -78,7 +78,7 @@ def harvester_args(request):
 @pytest.fixture
 def harvester(harvester_args):
     harvester = Harvester(*harvester_args)
-    client = harvester._client
+    client = harvester.client
     yield harvester
     if harvester._shutdown.is_set():
         assert client.closed, "Client is not closed."
@@ -86,7 +86,7 @@ def harvester(harvester_args):
 
 def test_run_once(harvester):
     harvester.harvest_interval = 0
-    client = harvester._client
+    client = harvester.client
     send_batch = client.send_batch
 
     def shutdown_after_send(*args, **kwargs):
@@ -105,7 +105,7 @@ def test_run_once(harvester):
 
 
 def test_run_flushes_data_on_shutdown(harvester):
-    client = harvester._client
+    client = harvester.client
 
     item = object()
     harvester.batch.record(item)
@@ -120,7 +120,7 @@ def test_run_flushes_data_on_shutdown(harvester):
 
 
 def test_empty_items_not_sent(harvester):
-    client = harvester._client
+    client = harvester.client
 
     # Set shutdown event
     harvester._shutdown.set()
@@ -133,7 +133,7 @@ def test_empty_items_not_sent(harvester):
 
 
 def test_harvester_terminates_at_shutdown(harvester):
-    client = harvester._client
+    client = harvester.client
 
     # Set the interval high enough so that send is never called unless shutdown
     # occurs
@@ -170,7 +170,7 @@ def test_harvester_handles_send_exception(caplog):
 
 
 def test_harvester_send_failed(caplog, harvester):
-    client = harvester._client
+    client = harvester.client
     client.response.status = 500
     client.response.ok = False
 


### PR DESCRIPTION
This PR makes the client attribute on the `Harvester` class public since the `Harvester.batch` is also public.

This will allow users to manually flush data from the batch to the client immediately for use cases that require data to immediately be sent.