### PR TITLE
retry once on connection errors

### DIFF
--- a/src/newrelic_telemetry_sdk/client.py
+++ b/src/newrelic_telemetry_sdk/client.py
@@ -118,7 +118,7 @@ class Client(object):
             }
         )
         retries = urllib3.Retry(
-            total=False, connect=None, read=None, redirect=0, status=None
+            total=None, connect=1, read=None, redirect=0, status=None
         )
 
         # Check if https traffic should be proxied and pass the proxy


### PR DESCRIPTION
We're periodically (almost hourly) seeing ConnectionResetByPeer, and this seems like it should be retryable.

```Traceback (most recent call last):
  File "/opt/conda/envs/airflow_env/lib/python3.7/site-packages/newrelic_telemetry_sdk/harvester.py", line 75, in _send
    response = self.client.send_batch(*flush_result)
  File "/opt/conda/envs/airflow_env/lib/python3.7/site-packages/newrelic_telemetry_sdk/client.py", line 228, in send_batch
    return self._pool.urlopen("POST", self.PATH, body=payload)
  File "/opt/conda/envs/airflow_env/lib/python3.7/site-packages/urllib3/connectionpool.py", line 725, in urlopen
    method, url, error=e, _pool=self, _stacktrace=sys.exc_info()[2]
  File "/opt/conda/envs/airflow_env/lib/python3.7/site-packages/urllib3/util/retry.py", line 379, in increment
    raise six.reraise(type(error), error, _stacktrace)
  File "/opt/conda/envs/airflow_env/lib/python3.7/site-packages/urllib3/packages/six.py", line 734, in reraise
    raise value.with_traceback(tb)
  File "/opt/conda/envs/airflow_env/lib/python3.7/site-packages/urllib3/connectionpool.py", line 677, in urlopen
    chunked=chunked,
  File "/opt/conda/envs/airflow_env/lib/python3.7/site-packages/newrelic/hooks/external_urllib3.py", line 18, in _nr_wrapper_make_request_
    return wrapped(*args, **kwargs)
  File "/opt/conda/envs/airflow_env/lib/python3.7/site-packages/urllib3/connectionpool.py", line 426, in _make_request
    six.raise_from(e, None)
  File "<string>", line 3, in raise_from
  File "/opt/conda/envs/airflow_env/lib/python3.7/site-packages/urllib3/connectionpool.py", line 421, in _make_request
    httplib_response = conn.getresponse()
  File "/opt/conda/envs/airflow_env/lib/python3.7/site-packages/newrelic/hooks/external_httplib.py", line 62, in httplib_getresponse_wrapper
    return wrapped(*args, **kwargs)
  File "/opt/conda/envs/airflow_env/lib/python3.7/http/client.py", line 1321, in getresponse
    response.begin()
  File "/opt/conda/envs/airflow_env/lib/python3.7/http/client.py", line 296, in begin
    version, status, reason = self._read_status()
  File "/opt/conda/envs/airflow_env/lib/python3.7/http/client.py", line 257, in _read_status
    line = str(self.fp.readline(_MAXLINE + 1), "iso-8859-1")
  File "/opt/conda/envs/airflow_env/lib/python3.7/socket.py", line 589, in readinto
    return self._sock.recv_into(b)
  File "/opt/conda/envs/airflow_env/lib/python3.7/ssl.py", line 1052, in recv_into
    return self.read(nbytes, buffer)
  File "/opt/conda/envs/airflow_env/lib/python3.7/ssl.py", line 911, in read
    return self._sslobj.read(len, buffer)
urllib3.exceptions.ProtocolError: ('Connection aborted.', ConnectionResetError(104, 'Connection reset by peer'))```