### PR TITLE
Add extract_host_from_url utility function.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -50,3 +50,8 @@ Harvester
     :exclude-members: EVENT_CLS, run, daemon
     :show-inheritance:
     :inherited-members:
+
+
+Utilities
+---------
+.. autofunction:: newrelic_telemetry_sdk.client.extract_host_from_url

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,6 +50,17 @@ xfail_strict = true
 markers =
     client_args: Extra arguments that are provided when constructing the client.
 
+[tool:isort]
+multi_line_output = 3
+include_trailing_comma = True
+force_grid_wrap = 0
+use_parentheses = True
+line_length = 88
+known_first_party =
+    newrelic_telemetry_sdk
+known_third_party =
+    pytest
+
 [flake8]
 max-line-length = 88
 ignore = W503,E203

--- a/src/newrelic_telemetry_sdk/__init__.py
+++ b/src/newrelic_telemetry_sdk/__init__.py
@@ -12,18 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from newrelic_telemetry_sdk.batch import EventBatch, SpanBatch
 from newrelic_telemetry_sdk.client import (
-    SpanClient,
-    MetricClient,
     EventClient,
     HTTPError,
+    MetricClient,
+    SpanClient,
+    extract_host_from_url,
 )
-from newrelic_telemetry_sdk.span import Span
-from newrelic_telemetry_sdk.metric import GaugeMetric, CountMetric, SummaryMetric
 from newrelic_telemetry_sdk.event import Event
-from newrelic_telemetry_sdk.metric_batch import MetricBatch
-from newrelic_telemetry_sdk.batch import SpanBatch, EventBatch
 from newrelic_telemetry_sdk.harvester import Harvester
+from newrelic_telemetry_sdk.metric import CountMetric, GaugeMetric, SummaryMetric
+from newrelic_telemetry_sdk.metric_batch import MetricBatch
+from newrelic_telemetry_sdk.span import Span
 
 try:
     from newrelic_telemetry_sdk.version import version as __version__
@@ -44,4 +45,5 @@ __all__ = (
     "SpanBatch",
     "EventBatch",
     "Harvester",
+    "extract_host_from_url",
 )

--- a/src/newrelic_telemetry_sdk/client.py
+++ b/src/newrelic_telemetry_sdk/client.py
@@ -15,6 +15,7 @@
 import json
 import logging
 import uuid
+import warnings
 import zlib
 
 import urllib3
@@ -40,6 +41,10 @@ __all__ = ("SpanClient", "MetricClient", "EventClient", "HTTPError", "HTTPRespon
 
 class HTTPError(ValueError):
     """Unexpected HTTP Status"""
+
+
+class AlternativeWarning(UserWarning):
+    """Warns a user there is an alternative"""
 
 
 class HTTPResponse(urllib3.HTTPResponse):
@@ -333,3 +338,22 @@ class EventClient(Client):
         :rtype: HTTPResponse
         """
         return super(EventClient, self).send_batch(items, None)
+
+
+def extract_host_from_url(url):
+    """Returns the host component of a URL
+
+    .. warning::
+        A warning will be emitted if :py:meth:`extract_host_from_url` is used.
+
+        :py:meth:`extract_host_from_url` is not recommended for general use.
+        It is recommended that the host component be used directly rather than
+        in URL form.
+
+    :param url: The URL to parse.
+    :type url: str
+    """
+    host = parse_url(url).host
+    message = "Use host={!r} directly rather than extract_host_from_url.".format(host)
+    warnings.warn(message, AlternativeWarning)
+    return host

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -46,7 +46,10 @@ def test_event_optional(arg_name, arg_value, event_key, event_value):
 
 @pytest.mark.parametrize(
     "attribute_name,attribute_value",
-    (("event_type", "event"), ("timestamp_ms", 1000),),
+    (
+        ("event_type", "event"),
+        ("timestamp_ms", 1000),
+    ),
 )
 def test_event_attributes(attribute_name, attribute_value):
     event = Event("event", timestamp_ms=1000)

--- a/tests/test_metric_batch.py
+++ b/tests/test_metric_batch.py
@@ -114,7 +114,14 @@ def test_different_metric(metric_a, metric_b):
     assert len(batch._internal_batch) == 2
 
 
-@pytest.mark.parametrize("tags", (None, {"foo": "bar"}, CustomMapping(),))
+@pytest.mark.parametrize(
+    "tags",
+    (
+        None,
+        {"foo": "bar"},
+        CustomMapping(),
+    ),
+)
 def test_flush(monkeypatch, tags):
     DELTA = 4.0
     current_t = [1.0]


### PR DESCRIPTION
This PR adds a helper function to extract the host from a URL. This method is generally only used for compatibility with the infinite tracing UI. A warning message is emitted with instructions on how to modify the code to use the parsed host directly rather than using the helper function.