### PR TITLE
Add timeout

### DIFF
--- a/src/newrelic_telemetry_sdk/client.py
+++ b/src/newrelic_telemetry_sdk/client.py
@@ -333,6 +333,8 @@ class EventClient(Client):
 
         :param items: An iterable of items to send to New Relic.
         :type items: list or tuple
+        :param timeout: (optional)  a timeout in seconds for sending the request
+        :type timeout: int
 
         :rtype: HTTPResponse
         """

--- a/src/newrelic_telemetry_sdk/client.py
+++ b/src/newrelic_telemetry_sdk/client.py
@@ -235,7 +235,9 @@ class Client(object):
         headers["x-request-id"] = str(uuid.uuid4())
 
         payload = self._create_payload(items, common)
-        return self._pool.urlopen("POST", self.PATH, body=payload, headers=headers, timeout=timeout)
+        return self._pool.urlopen(
+            "POST", self.PATH, body=payload, headers=headers, timeout=timeout
+        )
 
 
 class SpanClient(Client):

--- a/src/newrelic_telemetry_sdk/client.py
+++ b/src/newrelic_telemetry_sdk/client.py
@@ -204,17 +204,18 @@ class Client(object):
 
         return self._compress_payload(payload)
 
-    def send(self, item):
+    def send(self, item, timeout=None):
         """Send a single item
 
         :param item: The object to send
         :type item: dict
-
+        :param timeout: (optional)  a timeout in seconds for sending the request
+        :type timeout: int
         :rtype: HTTPResponse
         """
-        return self.send_batch((item,))
+        return self.send_batch((item,), timeout=timeout)
 
-    def send_batch(self, items, common=None):
+    def send_batch(self, items, common=None, timeout=None):
         """Send a batch of items
 
         :param items: An iterable of items to send to New Relic.
@@ -222,7 +223,8 @@ class Client(object):
         :param common: (optional) A map of attributes that will be set on each
             item.
         :type common: dict
-
+        :param timeout: (optional)  a timeout in seconds for sending the request
+        :type timeout: int
         :rtype: HTTPResponse
         """
         # Specifying the headers argument overrides any base headers existing
@@ -233,7 +235,7 @@ class Client(object):
         headers["x-request-id"] = str(uuid.uuid4())
 
         payload = self._create_payload(items, common)
-        return self._pool.urlopen("POST", self.PATH, body=payload, headers=headers)
+        return self._pool.urlopen("POST", self.PATH, body=payload, headers=headers, timeout=timeout)
 
 
 class SpanClient(Client):

--- a/src/newrelic_telemetry_sdk/client.py
+++ b/src/newrelic_telemetry_sdk/client.py
@@ -326,7 +326,7 @@ class EventClient(Client):
 
         return self._compress_payload(payload)
 
-    def send_batch(self, items):
+    def send_batch(self, items, timeout=None):
         """Send a batch of items
 
         :param items: An iterable of items to send to New Relic.
@@ -334,7 +334,7 @@ class EventClient(Client):
 
         :rtype: HTTPResponse
         """
-        return super(EventClient, self).send_batch(items, None)
+        return super(EventClient, self).send_batch(items, None, timeout=timeout)
 
 
 class LogClient(Client):


### PR DESCRIPTION
I often face the problem when sending a New Relic event from a Databricks notebook that the request does not time out.

I would like to add the `timeout` parameter so it can fail faster and I can implement retries in my code.

Please let me know if there's something missing in my PR and any feedback is welcome!

Thank you!