### PR TITLE
Remove py2.7

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
         architecture: x64
@@ -33,8 +33,8 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
         architecture: x64

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10", pypy2.7,pypy3.9]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10",pypy3.9]
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 5
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10",pypy3.9]
+        python-version: ["3.7", "3.8", "3.9", "3.10",pypy3.9]
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 5

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ classifiers =
 [options]
 setup_requires =
     setuptools_scm
-python_requires !=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*
+python_requires = !=2.*,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*
 package_dir=
     =src
 packages=find:

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,8 +17,8 @@ classifiers =
     Topic :: System :: Monitoring
     Programming Language :: Python :: Implementation :: PyPy
     Programming Language :: Python :: Implementation :: CPython
-    Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.7
+    ; Programming Language :: Python :: 2
+    ; Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
@@ -31,7 +31,7 @@ classifiers =
 [options]
 setup_requires =
     setuptools_scm
-python_requires = >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*
+python_requires !=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*
 package_dir=
     =src
 packages=find:

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist =
-    py36
     py37
     py38
     py39

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,10 @@
 [tox]
 envlist =
-    py27
     py36
     py37
     py38
     py39
     py310
-    pypy
     pypy3
     lint
     docs


### PR DESCRIPTION
Python 2.7 [support was dropped](https://github.com/actions/setup-python/issues/672) on June 19th. This solution is a TEMPORARY one that disables python 2.7 and pypy2 testing until a more permanent fix is implemented.