### PR TITLE
Update python versions supported and tested

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10",pypy3.9]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11" ,pypy3.9]
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 5

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,16 +15,13 @@ license_files =
 classifiers =
     Development Status :: 3 - Alpha
     Topic :: System :: Monitoring
-    Programming Language :: Python :: Implementation :: PyPy
+    Programming Language :: Python :: Implementation :: PyPy3
     Programming Language :: Python :: Implementation :: CPython
-    ; Programming Language :: Python :: 2
-    ; Programming Language :: Python :: 2.7
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Operating System :: OS Independent
     License :: OSI Approved :: Apache Software License
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
     py38
     py39
     py310
+    py311
     pypy3
     lint
     docs


### PR DESCRIPTION
This PR removes Python 3.6 and adds Python 3.11 to match the Python versions supported in the newrelic-python-agent