### PR TITLE
Misc Updates

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", pypy3.9]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", pypy3.10]
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 5

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -60,7 +60,7 @@ master_doc = "index"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -111,6 +111,6 @@ htmlhelp_basename = "newrelic-telemetry-sdkdoc"
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    "https://docs.python.org/3/": None,
-    "https://urllib3.readthedocs.io/en/latest/": None,
+    "python": ("https://docs.python.org/3/", None),
+    "urllib3": ("https://urllib3.readthedocs.io/en/latest/", None),
 }

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Operating System :: OS Independent
     License :: OSI Approved :: Apache Software License
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,8 +6,9 @@ envlist =
     py39
     py310
     py311
+    py312
     pypy2.7
-    pypy3.9
+    pypy3.10
     lint
     docs
 

--- a/tox.ini
+++ b/tox.ini
@@ -32,5 +32,5 @@ deps =
 [testenv:docs]
 commands = sphinx-build -d "{toxinidir}/docs_doctree" "{toxinidir}/docs/" "{toxinidir}/docs/_build" -W {posargs}
 deps =
-    sphinx<5
+    sphinx<8
     sphinx_rtd_theme


### PR DESCRIPTION
* Add classifiers for Python 3.12
* Add tests for Python 3.12
* Update pypy3.9 to pypy3.10
* Update sphinx to v7
  * Update sphinx config to work with v7
  * [Relevant docs](https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#confval-intersphinx_mapping)