### PR TITLE
Fix ResponseCls no longer existing on HTTPSConnectionPool

### DIFF
--- a/src/newrelic_telemetry_sdk/client.py
+++ b/src/newrelic_telemetry_sdk/client.py
@@ -45,13 +45,13 @@ class HTTPError(ValueError):
 class HTTPResponse(urllib3.HTTPResponse):
     """A wrapper for urllib3.HTTPResponse, providing additional helper methods"""
 
-    def  __init__(self, urllib3_response):
+    def __init__(self, response):
         """Initialize the wrapper with an urllib3.HTTPResponse object"""
-        self._urllib3_response = urllib3_response
+        self._response = response
 
     def __getattr__(self, name):
         """Expose attributes and methods of the original urllib3.HTTPResponse object"""
-        return getattr(self._urllib3_response, name)
+        return getattr(self._response, name)
 
     def json(self):
         """Returns the json-encoded content of a response.
@@ -74,8 +74,8 @@ class HTTPResponse(urllib3.HTTPResponse):
             raise HTTPError(self.status, self)
 
 
-class HTTPSConnectionPool(urllib3.HTTPSConnectionPool):
-    """Empty wrapper, only kept for backwards compatibility"""
+# No longer a subclass, kept for backwards compatibility
+HTTPSConnectionPool = urllib3.HTTPSConnectionPool
 
 
 class Client(object):
@@ -239,7 +239,9 @@ class Client(object):
             "POST", self.PATH, body=payload, headers=headers, timeout=timeout
         )
         if not isinstance(urllib3_response, urllib3.HTTPResponse):
-            raise ValueError("Expected urllib3.HTTPResponse, got {}".format(type(urllib3_response)))
+            raise ValueError(
+                "Expected urllib3.HTTPResponse, got {}".format(type(urllib3_response))
+            )
 
         return HTTPResponse(urllib3_response)
 

--- a/src/newrelic_telemetry_sdk/client.py
+++ b/src/newrelic_telemetry_sdk/client.py
@@ -43,12 +43,15 @@ class HTTPError(ValueError):
 
 
 class HTTPResponse(urllib3.HTTPResponse):
-    """Response object with helper methods
+    """A wrapper for urllib3.HTTPResponse, providing additional helper methods"""
 
-    :ivar headers: The HTTP headers
-    :ivar status: The HTTP status code
-    :ivar data: The raw byte encoded response data
-    """
+    def  __init__(self, urllib3_response):
+        """Initialize the wrapper with an urllib3.HTTPResponse object"""
+        self._urllib3_response = urllib3_response
+
+    def __getattr__(self, name):
+        """Expose attributes and methods of the original urllib3.HTTPResponse object"""
+        return getattr(self._urllib3_response, name)
 
     def json(self):
         """Returns the json-encoded content of a response.
@@ -72,9 +75,7 @@ class HTTPResponse(urllib3.HTTPResponse):
 
 
 class HTTPSConnectionPool(urllib3.HTTPSConnectionPool):
-    """Connection pool providing HTTPResponse objects"""
-
-    ResponseCls = HTTPResponse
+    """Empty wrapper, only kept for backwards compatibility"""
 
 
 class Client(object):
@@ -234,9 +235,13 @@ class Client(object):
         headers["x-request-id"] = str(uuid.uuid4())
 
         payload = self._create_payload(items, common)
-        return self._pool.urlopen(
+        urllib3_response = self._pool.urlopen(
             "POST", self.PATH, body=payload, headers=headers, timeout=timeout
         )
+        if not isinstance(urllib3_response, urllib3.HTTPResponse):
+            raise ValueError("Expected urllib3.HTTPResponse, got {}".format(type(urllib3_response)))
+
+        return HTTPResponse(urllib3_response)
 
 
 class SpanClient(Client):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -20,6 +20,7 @@ import uuid
 import zlib
 
 import pytest
+import urllib3
 from urllib3 import HTTPConnectionPool
 
 from newrelic_telemetry_sdk.client import (
@@ -89,13 +90,14 @@ def capture_request(fn):
 
 
 def disable_sending(*args, **kwargs):
-    response = HTTPResponse(status=202)
-    response.request = Request(*args, **kwargs)
+    urllib3_response = urllib3.HTTPResponse(status=202)
+    urllib3_response.request = Request(*args, **kwargs)
+    response = HTTPResponse(urllib3_response)
     return response
 
-
 def test_response_json():
-    response = HTTPResponse(status=200, body=b"{}")
+    urllib3_response = urllib3.HTTPResponse(status=200, body=b"{}")
+    response = HTTPResponse(urllib3_response)
     assert response.json() == {}
 
 
@@ -103,18 +105,21 @@ def test_response_json():
     "status,expected", ((199, False), (200, True), (299, True), (300, False))
 )
 def test_response_ok(status, expected):
-    response = HTTPResponse(status=status)
+    urllib3_response = urllib3.HTTPResponse(status=status)
+    response = HTTPResponse(urllib3_response)
     assert response.ok is expected
 
 
 def test_response_raise_for_status_error():
-    response = HTTPResponse(status=500)
+    urllib3_response = urllib3.HTTPResponse(status=500)
+    response = HTTPResponse(urllib3_response)
     with pytest.raises(HTTPError):
         response.raise_for_status()
 
 
 def test_response_raise_for_status_ok():
-    response = HTTPResponse(status=200)
+    urllib3_response = urllib3.HTTPResponse(status=200)
+    response = HTTPResponse(urllib3_response)
     response.raise_for_status()
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -20,8 +20,7 @@ import uuid
 import zlib
 
 import pytest
-import urllib3
-from urllib3 import HTTPConnectionPool
+from urllib3 import HTTPConnectionPool, HTTPResponse as URLLib3HTTPResponse
 
 from newrelic_telemetry_sdk.client import (
     EventClient,
@@ -90,13 +89,14 @@ def capture_request(fn):
 
 
 def disable_sending(*args, **kwargs):
-    urllib3_response = urllib3.HTTPResponse(status=202)
+    urllib3_response = URLLib3HTTPResponse(status=202)
     urllib3_response.request = Request(*args, **kwargs)
     response = HTTPResponse(urllib3_response)
     return response
 
+
 def test_response_json():
-    urllib3_response = urllib3.HTTPResponse(status=200, body=b"{}")
+    urllib3_response = URLLib3HTTPResponse(status=200, body=b"{}")
     response = HTTPResponse(urllib3_response)
     assert response.json() == {}
 
@@ -105,20 +105,20 @@ def test_response_json():
     "status,expected", ((199, False), (200, True), (299, True), (300, False))
 )
 def test_response_ok(status, expected):
-    urllib3_response = urllib3.HTTPResponse(status=status)
+    urllib3_response = URLLib3HTTPResponse(status=status)
     response = HTTPResponse(urllib3_response)
     assert response.ok is expected
 
 
 def test_response_raise_for_status_error():
-    urllib3_response = urllib3.HTTPResponse(status=500)
+    urllib3_response = URLLib3HTTPResponse(status=500)
     response = HTTPResponse(urllib3_response)
     with pytest.raises(HTTPError):
         response.raise_for_status()
 
 
 def test_response_raise_for_status_ok():
-    urllib3_response = urllib3.HTTPResponse(status=200)
+    urllib3_response = URLLib3HTTPResponse(status=200)
     response = HTTPResponse(urllib3_response)
     response.raise_for_status()
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -123,6 +123,12 @@ def test_response_raise_for_status_ok():
     response.raise_for_status()
 
 
+def test_wrapped_response_attributes_available():
+    urllib3_response = URLLib3HTTPResponse(status=200)
+    response = HTTPResponse(urllib3_response)
+    assert response.status == 200
+
+
 @pytest.fixture
 def span_client(request, monkeypatch):
     host = os.environ.get("NEW_RELIC_HOST", "")

--- a/tests/test_client_proxy.py
+++ b/tests/test_client_proxy.py
@@ -2,7 +2,7 @@ import socket
 import threading
 import functools
 import logging
-from urllib3 import HTTPConnectionPool, exceptions
+from urllib3 import HTTPConnectionPool, exceptions, HTTPResponse
 
 try:
     from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -14,7 +14,6 @@ from newrelic_telemetry_sdk.client import (
     SpanClient,
     MetricClient,
     EventClient,
-    HTTPResponse,
 )
 import pytest
 


### PR DESCRIPTION
## Background

After https://github.com/newrelic/newrelic-telemetry-sdk-python/pull/72 was merged the `newrelic-telemetry-sdk` still does not work properly with `urllib3` v2.

___NOTE:__ https://github.com/newrelic/newrelic-telemetry-sdk-python/pull/72 was not merged into `main` but into [`develop-urllib3-v2`](https://github.com/newrelic/newrelic-telemetry-sdk-python/tree/develop-urllib3-v2)._

## What's the problem?

The issue is that in urllib3 v2, the `ResponseCls` class attribute was removed from the `HTTPSConnectionPool` class:
- https://github.com/urllib3/urllib3/issues/2648

We were depending on `ResponseCls` to cause `urllib3` to return our custom `HTTPResponse` wrapper (which has extra methods like `ok` and `json()` methods).

## What's the solution?

As a workaround that is fully backwards compatible (and works with both `urllib3` v1 and v2), I have changed our wrapper class to be a true wrapper which delegates unknown attribute calls to the inner HTTPResponse object by overloading the `__getattr__` method.