### PR TITLE
Add Build Provenance to GitHub

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,6 +65,12 @@ jobs:
       - name: Upload Package
         uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # 1.12.4
 
+      - name: Attest
+        uses: actions/attest-build-provenance@db473fddc028af60658334401dc6fa3ffd8669fd # 2.3.0
+        id: attest
+        with:
+          subject-path: ./dist/*
+
   docs:
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
# Overview

* Add build provenance to GitHub alongside PyPi.