### PR TITLE
More Specific Attestation List

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,7 +69,9 @@ jobs:
         uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # 3.0.0
         id: attest
         with:
-          subject-path: ./dist/*
+          subject-path: |
+            ./dist/*.whl
+            ./dist/*.tar.gz
 
   docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Overview

Copy of https://github.com/newrelic/newrelic-python-agent/pull/1476 for this repo.

* Specify file extensions of artifacts to attest on deploy to remove attestations of attestations.
  * See [example](https://github.com/newrelic/newrelic-python-agent/attestations/9684065) where there are attestations for `.publish.attestation` files. These are attestations for PyPI and should not be included.